### PR TITLE
docs: add try-gavel-on-open-source tutorial guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ EOF
 
 ## Guides
 
+- **[Try Gavel on Open Source Code](docs/guides/try-on-open-source.md)** — Run Gavel on real repositories in Go, Python, and TypeScript
 - **[Gate PRs with AI Code Review](docs/guides/ci-pr-gating.md)** — Set up GitHub Actions to automatically analyze every PR
 - **[See Findings in Your Editor](docs/guides/editor-integration.md)** — View Gavel findings inline in VS Code or Neovim
 

--- a/docs/guides/try-on-open-source.md
+++ b/docs/guides/try-on-open-source.md
@@ -1,0 +1,428 @@
+# Try Gavel on Open Source Code
+
+By the end of this guide you will have run Gavel on three open-source repositories in Go, Python, and TypeScript -- using all three input modes.
+
+Each example uses a deliberately vulnerable or well-known project so that Gavel produces real findings you can inspect. You will learn the three ways to feed code into Gavel (`--dir`, `--files`, `--diff`) and how to read the output.
+
+## Prerequisites
+
+- **Gavel binary installed** -- download from the [releases page](https://github.com/chris-regnier/gavel/releases) or follow the [README installation instructions](../../README.md#installation)
+- **An LLM provider** -- pick the one that fits your situation:
+
+| Priority | Provider | Model | Setup |
+|----------|----------|-------|-------|
+| Free/local | Ollama | `qwen2.5-coder:7b` | `ollama pull qwen2.5-coder:7b` |
+| Easy cloud | OpenRouter | `google/gemini-2.0-flash-exp` | API key from [openrouter.ai](https://openrouter.ai) |
+| Best quality | Anthropic | `claude-haiku-4-5` | API key from [console.anthropic.com](https://console.anthropic.com) |
+
+### Provider configuration
+
+Every example in this guide needs a `.gavel/policies.yaml` file in the repository you are analyzing. Pick the config block for your provider and use it in all three examples.
+
+**Ollama (free, local):**
+
+```yaml
+provider:
+  name: ollama
+  ollama:
+    model: qwen2.5-coder:7b
+    base_url: http://localhost:11434/v1
+
+policies:
+  shall-be-merged:
+    description: "Shall this code be merged?"
+    severity: error
+    instruction: "Flag code that is risky, sloppy, untested, or unnecessarily complex."
+    enabled: true
+```
+
+If you use Ollama, make sure the server is running (`ollama serve`) and you have pulled the model (`ollama pull qwen2.5-coder:7b`) before continuing.
+
+**OpenRouter:**
+
+```yaml
+provider:
+  name: openrouter
+  openrouter:
+    model: google/gemini-2.0-flash-exp
+
+policies:
+  shall-be-merged:
+    description: "Shall this code be merged?"
+    severity: error
+    instruction: "Flag code that is risky, sloppy, untested, or unnecessarily complex."
+    enabled: true
+```
+
+Set your API key before running Gavel:
+
+```bash
+export OPENROUTER_API_KEY="your-key-here"
+```
+
+**Anthropic:**
+
+```yaml
+provider:
+  name: anthropic
+  anthropic:
+    model: claude-haiku-4-5
+
+policies:
+  shall-be-merged:
+    description: "Shall this code be merged?"
+    severity: error
+    instruction: "Flag code that is risky, sloppy, untested, or unnecessarily complex."
+    enabled: true
+```
+
+Set your API key before running Gavel:
+
+```bash
+export ANTHROPIC_API_KEY="your-key-here"
+```
+
+With your provider chosen and key exported, you are ready to analyze some code.
+
+---
+
+## Example 1: Go -- Directory Scan
+
+**Repo:** [0c34/govwa](https://github.com/0c34/govwa) -- Go Vulnerable Web Application, a deliberately insecure web app with ~20 Go files.
+
+**Input mode:** `--dir` scans every file in a directory tree.
+
+### Clone the repo
+
+```bash
+git clone https://github.com/0c34/govwa.git
+cd govwa
+```
+
+### Configure Gavel
+
+```bash
+mkdir -p .gavel
+```
+
+Create `.gavel/policies.yaml` with the config block for your chosen provider from the [prerequisites section](#provider-configuration).
+
+### Run the analysis
+
+```bash
+gavel analyze --dir .
+```
+
+Gavel reads every Go file in the repository, sends each one to your LLM provider along with the enabled policies, and prints a JSON verdict to stdout.
+
+### Read the output
+
+The verdict tells you Gavel's gate decision -- whether this code should be merged, reviewed, or rejected. Here is a plausible output for this repository:
+
+```json
+{
+  "decision": "reject",
+  "reason": "Decision: reject based on 5 findings",
+  "relevant_findings": [
+    {
+      "ruleId": "S3649",
+      "level": "error",
+      "message": {
+        "text": "Possible SQL injection vulnerability: raw user input interpolated into SQL query via fmt.Sprintf"
+      },
+      "locations": [
+        {
+          "physicalLocation": {
+            "artifactLocation": {
+              "uri": "vulnerability/sqli/function.go"
+            },
+            "region": {
+              "startLine": 14
+            }
+          }
+        }
+      ],
+      "properties": {
+        "gavel/confidence": 0.95,
+        "gavel/explanation": "The function UnsafeQueryGetData builds a SQL query using fmt.Sprintf with user-supplied uid directly interpolated into the query string, allowing SQL injection.",
+        "gavel/recommendation": "Use parameterized queries with placeholder arguments instead of string interpolation."
+      }
+    }
+  ]
+}
+```
+
+Here is what each part means:
+
+- **`decision`** -- the gate verdict. `"reject"` means at least one finding crossed the confidence and severity threshold. Other possible values are `"merge"` (no findings) and `"review"` (findings exist but none are severe enough to auto-reject).
+- **`reason`** -- a human-readable summary of why the decision was made.
+- **`relevant_findings`** -- the SARIF results that drove the decision. Each finding includes:
+  - **`ruleId`** -- the rule that matched (here `S3649`, a SonarQube SQL injection rule).
+  - **`level`** -- severity: `error`, `warning`, or `note`.
+  - **`message.text`** -- what the AI found.
+  - **`locations`** -- where in the code the issue appears, with file path and line number.
+  - **`properties`** -- Gavel-specific metadata under the `gavel/` prefix:
+    - **`gavel/confidence`** -- how confident the AI is in this finding (0.0 to 1.0).
+    - **`gavel/explanation`** -- the AI's reasoning for flagging this code.
+    - **`gavel/recommendation`** -- a concrete suggestion for fixing the issue.
+
+> Your exact findings will differ depending on your provider and model. The structure is always the same.
+
+### Dig deeper
+
+Gavel writes the full SARIF log and verdict to `.gavel/results/`. Find the latest run:
+
+```bash
+ls -t .gavel/results/ | head -1
+```
+
+Open the SARIF file to see every finding, not just the ones that drove the verdict:
+
+```bash
+cat .gavel/results/$(ls -t .gavel/results/ | head -1)/sarif.json | jq .
+```
+
+The SARIF file is a standard [SARIF 2.1.0](https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html) log. You can open it in VS Code with the [SARIF Viewer extension](https://marketplace.visualstudio.com/items?itemName=MS-SarifVSCode.sarif-viewer) or process it with any SARIF-compatible tool.
+
+### Try a different persona
+
+Re-run with the security persona to get findings focused on OWASP Top 10 and authentication issues:
+
+```bash
+gavel analyze --dir . --persona security
+```
+
+The security persona shifts the AI's focus toward injection, broken authentication, sensitive data exposure, and other security-specific concerns. Compare the output with the default `code-reviewer` persona to see how the perspective changes.
+
+---
+
+## Example 2: Python -- File-Targeted Scan
+
+**Repo:** [adeyosemanputra/pygoat](https://github.com/adeyosemanputra/pygoat) -- a Django-based intentionally vulnerable application for learning about web security.
+
+**Input mode:** `--files` analyzes specific files instead of an entire directory. This is useful when you know which files you want to check or when a full directory scan would be too slow.
+
+### Clone the repo
+
+```bash
+git clone https://github.com/adeyosemanputra/pygoat.git
+cd pygoat
+```
+
+### Configure Gavel
+
+```bash
+mkdir -p .gavel
+```
+
+Create `.gavel/policies.yaml` with your chosen provider config from the [prerequisites section](#provider-configuration).
+
+### Run the analysis
+
+```bash
+gavel analyze --files pygoat/settings.py,introduction/views.py
+```
+
+The `--files` flag takes a comma-separated list of paths relative to the current directory. Gavel only analyzes the files you specify -- nothing else in the repository is touched.
+
+### Read the output
+
+A plausible verdict for these two files:
+
+```json
+{
+  "decision": "reject",
+  "reason": "Decision: reject based on 3 findings",
+  "relevant_findings": [
+    {
+      "ruleId": "S2068",
+      "level": "error",
+      "message": {
+        "text": "Hardcoded secret: Django SECRET_KEY is set to a static string in source code"
+      },
+      "locations": [
+        {
+          "physicalLocation": {
+            "artifactLocation": { "uri": "pygoat/settings.py" },
+            "region": { "startLine": 23 }
+          }
+        }
+      ],
+      "properties": {
+        "gavel/confidence": 0.97,
+        "gavel/explanation": "The SECRET_KEY setting is hardcoded as a string literal. This key is used for cryptographic signing in Django and must not be committed to version control.",
+        "gavel/recommendation": "Load SECRET_KEY from an environment variable or a secrets manager."
+      }
+    },
+    {
+      "ruleId": "S2068",
+      "level": "error",
+      "message": {
+        "text": "Hardcoded credentials: DEBUG mode enabled with default database password"
+      },
+      "locations": [
+        {
+          "physicalLocation": {
+            "artifactLocation": { "uri": "pygoat/settings.py" },
+            "region": { "startLine": 26 }
+          }
+        }
+      ],
+      "properties": {
+        "gavel/confidence": 0.92,
+        "gavel/explanation": "DEBUG is set to True and database credentials are hardcoded. In production this exposes detailed error pages and uses known credentials.",
+        "gavel/recommendation": "Set DEBUG via an environment variable and use a secrets manager for database credentials."
+      }
+    }
+  ]
+}
+```
+
+Notice that both findings use the same rule ID (`S2068` -- hardcoded credentials) but flag different locations and provide distinct explanations. The AI treats each occurrence independently.
+
+> Your exact findings will differ depending on your provider and model. The structure is always the same.
+
+### Dig deeper
+
+Same pattern as before -- find the latest results:
+
+```bash
+ls -t .gavel/results/ | head -1
+```
+
+---
+
+## Example 3: TypeScript -- Diff Scan
+
+**Repo:** [gothinkster/node-express-realworld-example-app](https://github.com/gothinkster/node-express-realworld-example-app) -- an Express.js implementation of the RealWorld API spec.
+
+**Input mode:** `--diff` analyzes only the lines changed in a unified diff. This is the fastest and most focused mode -- it is how Gavel works in CI, where `gh pr diff` pipes into `gavel analyze --diff -`.
+
+### Clone the repo
+
+```bash
+git clone https://github.com/gothinkster/node-express-realworld-example-app.git
+cd node-express-realworld-example-app
+```
+
+### Configure Gavel
+
+```bash
+mkdir -p .gavel
+```
+
+Create `.gavel/policies.yaml` with your chosen provider config from the [prerequisites section](#provider-configuration).
+
+### Generate a diff
+
+To use diff mode, you need a unified diff. The easiest way is to generate one from the git history:
+
+```bash
+# See recent commits
+git log --oneline -10
+
+# Generate a patch from the last 5 commits
+git diff HEAD~5..HEAD > changes.patch
+```
+
+If the repository has fewer than 5 commits, adjust the range (e.g., `HEAD~2..HEAD`). You can also diff between any two branches or tags.
+
+### Run the analysis
+
+```bash
+gavel analyze --diff changes.patch
+```
+
+Gavel parses the unified diff, extracts only the changed hunks, and sends those to the LLM. Files that were not modified are ignored entirely.
+
+### Pipe directly from git
+
+You can skip the intermediate file and pipe the diff into Gavel via stdin:
+
+```bash
+git diff HEAD~5..HEAD | gavel analyze --diff -
+```
+
+The `-` argument tells Gavel to read the diff from stdin. This is the exact pattern used in CI workflows:
+
+```bash
+gh pr diff 42 | gavel analyze --diff -
+```
+
+### Read the output
+
+Because diff mode only analyzes changed lines, you will typically see fewer findings than a full directory scan. The verdict format is identical:
+
+```json
+{
+  "decision": "review",
+  "reason": "Decision: review based on 2 findings",
+  "relevant_findings": [
+    {
+      "ruleId": "shall-be-merged",
+      "level": "warning",
+      "message": {
+        "text": "Error from database query is not checked before using the result"
+      },
+      "locations": [
+        {
+          "physicalLocation": {
+            "artifactLocation": { "uri": "src/models/User.ts" },
+            "region": { "startLine": 45 }
+          }
+        }
+      ],
+      "properties": {
+        "gavel/confidence": 0.78,
+        "gavel/explanation": "The return value of the database query is used directly without checking for errors or null results.",
+        "gavel/recommendation": "Add error handling around the query and validate the result before accessing its properties."
+      }
+    }
+  ]
+}
+```
+
+Notice the `"review"` decision instead of `"reject"` -- the confidence is below the 0.8 threshold, so Gavel flags it for human review rather than blocking the merge.
+
+> Your exact findings will differ depending on your provider and model. The structure is always the same.
+
+### Why diff mode matters
+
+Diff mode is how Gavel delivers fast, focused PR reviews:
+
+- **Speed** -- only changed lines are analyzed, so even a large repository finishes quickly.
+- **Relevance** -- findings are scoped to the code that actually changed, reducing noise.
+- **CI integration** -- the `gh pr diff | gavel analyze --diff -` pattern is a single line in a GitHub Actions workflow. See the [CI/PR Gating Guide](ci-pr-gating.md) for the full setup.
+
+---
+
+## What You Have Learned
+
+You have now used all three Gavel input modes:
+
+| Mode | Flag | Best For |
+|------|------|----------|
+| Directory scan | `--dir .` | Full project analysis, onboarding to a new codebase |
+| File-targeted | `--files a.py,b.py` | Checking specific files you are working on |
+| Diff scan | `--diff changes.patch` | PR review, CI pipelines, incremental analysis |
+
+Each mode produces the same SARIF output and verdict format. The only difference is what code gets sent to the LLM.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `OPENROUTER_API_KEY not set` | API key not exported in your shell | Run `export OPENROUTER_API_KEY="your-key"` before `gavel analyze` |
+| `ANTHROPIC_API_KEY not set` | API key not exported in your shell | Run `export ANTHROPIC_API_KEY="your-key"` before `gavel analyze` |
+| `connection refused` on port 11434 | Ollama server is not running | Start it with `ollama serve` |
+| `model not found` | Model not pulled or wrong name | Run `ollama pull qwen2.5-coder:7b` (Ollama) or check the model string matches your provider |
+| No output or empty findings | The LLM did not flag anything | Try a different model or add more specific policy instructions |
+| `--diff` produces no findings | Diff range has no code changes | Check that `git diff HEAD~5..HEAD` actually produces output before piping to Gavel |
+| Analysis is slow | Large files or slow model | Use `--files` to narrow scope, or switch to a faster model (`gemini-2.0-flash-exp`, `qwen2.5-coder:7b`) |
+
+## What's Next
+
+- **[Gate PRs with AI Code Review](ci-pr-gating.md)** -- automate Gavel in your CI pipeline with GitHub Actions
+- **[See Findings in Your Editor](editor-integration.md)** -- view findings inline in VS Code or Neovim
+- **[Custom Rules](../../README.md#custom-rules)** -- write your own analysis rules
+- **[Personas](../../README.md#personas)** -- switch between code-reviewer, architect, and security perspectives

--- a/docs/plans/2026-02-13-try-gavel-on-oss-design.md
+++ b/docs/plans/2026-02-13-try-gavel-on-oss-design.md
@@ -1,0 +1,104 @@
+# Design: Try Gavel on Open Source Code Guide
+
+**Date:** 2026-02-13
+**Type:** Onboarding tutorial (docs/guides/ page)
+**File:** `docs/guides/try-on-open-source.md`
+
+## Purpose
+
+Step-by-step tutorial for new users to try Gavel on real code immediately after installation. Uses three public, intentionally vulnerable repositories across Go, Python, and JavaScript to demonstrate all three input modes and guarantee interesting findings.
+
+## Structure
+
+1. Prerequisites & provider setup
+2. Example 1: Go — directory scan (`--dir`)
+3. Example 2: Python — file-targeted scan (`--files`)
+4. Example 3: JavaScript — diff scan (`--diff`)
+5. What's next (links to CI guide, editor integration, custom rules)
+
+## Provider Setup
+
+Three providers presented with copy-paste configs:
+
+| Provider | Setup | Cost |
+|----------|-------|------|
+| Ollama | `ollama pull qwen2.5-coder:7b` | Free |
+| OpenRouter | API key from openrouter.ai | ~$0.04/100 files |
+| Anthropic | API key from console.anthropic.com | ~$2.40/100 files |
+
+Each example includes `.gavel/policies.yaml` blocks for all three providers.
+
+## Example 1: Go — `0c34/govwa`
+
+- **Repo:** Go Vulnerable Web Application (~15 Go files)
+- **Mode:** `gavel analyze --dir .`
+- **Expected findings:** SQL injection (S3649), hardcoded credentials (S2068), error-ignored (S1086), empty error handlers (AST003), debug prints (S106)
+- **Extras:** Re-run with `--persona security` to show persona switching
+
+### Walkthrough
+
+1. Clone repo
+2. Create `.gavel/policies.yaml`
+3. Run `gavel analyze --dir .`
+4. Annotated verdict JSON walkthrough (decision, reason, relevant_findings)
+5. Dig into `.gavel/results/` SARIF file (gavel/explanation, gavel/recommendation)
+6. Re-run with `--persona security`
+
+## Example 2: Python — `OWASP/PyGoat`
+
+- **Repo:** Django-based intentionally vulnerable Python app
+- **Mode:** `gavel analyze --files <2-3 specific files>`
+- **Expected findings:** Hardcoded credentials (S2068), TODO/FIXME (S1135), long functions (AST001), deep nesting (AST002)
+
+### Walkthrough
+
+1. Clone repo
+2. Create `.gavel/policies.yaml`
+3. Run `gavel analyze --files <selected files>`
+4. Annotated verdict JSON walkthrough
+5. Dig into SARIF findings
+
+## Example 3: JavaScript — `gothinkster/node-express-realworld-example-app`
+
+- **Repo:** Express.js RealWorld API implementation (~20 files)
+- **Mode:** `gavel analyze --diff`
+- **Expected findings:** TODO comments (S1135), function-length (AST001), possibly hardcoded credentials in config
+
+### Walkthrough
+
+1. Clone repo
+2. Create `.gavel/policies.yaml`
+3. Generate diff from commit range: `git diff <older>..<newer> > changes.patch`
+4. Run `gavel analyze --diff changes.patch`
+5. Also show stdin variant: `git diff HEAD~3..HEAD | gavel analyze --diff -`
+6. Annotated verdict JSON walkthrough
+
+## Per-Example Template
+
+Each example follows:
+
+1. **Clone** — `git clone` + `cd`
+2. **Configure** — `.gavel/policies.yaml` with all three provider options
+3. **Run** — the `gavel analyze` command
+4. **Read the output** — annotated verdict JSON
+5. **Dig deeper** — SARIF file in `.gavel/results/`, `gavel/explanation` and `gavel/recommendation` properties
+
+## Resilience
+
+- Sample output blocks included so users know what to expect even if repos evolve
+- Each example notes "your exact findings may differ"
+- Examples are self-contained — user can jump to any one
+
+## Style
+
+- ~400-500 lines of markdown
+- Direct, second-person tone ("Clone the repo", "Run the command")
+- Consistent with existing guides (ci-pr-gating.md, editor-integration.md)
+- Title: "Try Gavel on Open Source Code"
+
+## What's Next Section
+
+Links to:
+- [Gate PRs with AI Code Review](ci-pr-gating.md)
+- [See Findings in Your Editor](editor-integration.md)
+- Custom rules and personas (README sections)

--- a/docs/plans/2026-02-13-try-gavel-on-oss-plan.md
+++ b/docs/plans/2026-02-13-try-gavel-on-oss-plan.md
@@ -1,0 +1,374 @@
+# Try Gavel on Open Source Code — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Create a docs/guides/ onboarding tutorial that walks new users through running Gavel on three public open-source repositories, demonstrating all three input modes (--dir, --files, --diff) across Go, Python, and JavaScript.
+
+**Architecture:** Single markdown file at `docs/guides/try-on-open-source.md` following the structure and tone of the existing guides (`ci-pr-gating.md`, `editor-integration.md`). A link is added to the README.md Guides section.
+
+**Tech Stack:** Markdown, Gavel CLI
+
+---
+
+### Task 1: Research target repositories
+
+Verify the three target repos exist, are public, and identify the specific files/paths to use in the guide.
+
+**Step 1: Verify repos and identify target files**
+
+Check each repo on GitHub:
+
+1. **Go — `0c34/govwa`**: Clone and list Go files. Identify 2-3 files likely to trigger findings (look for SQL queries, hardcoded passwords, empty error checks). The app is a vulnerable web app so most files should produce findings.
+
+2. **Python — `OWASP/PyGoat`**: Clone and list Python files. Identify 2-3 files to recommend for `--files` mode. Look for views or models with hardcoded credentials, long functions, TODO comments.
+
+3. **JS — `gothinkster/node-express-realworld-example-app`**: Clone and check `git log --oneline -10` to find a good commit range for diff mode. Identify commits that touch multiple files.
+
+**Step 2: Document findings**
+
+Record the specific files, commit SHAs, and expected rule triggers for each repo. These will be used in the guide's walkthrough sections.
+
+**Step 3: Commit research notes (optional)**
+
+If the research produces useful notes, append them to the design doc.
+
+---
+
+### Task 2: Write guide skeleton and prerequisites section
+
+**Files:**
+- Create: `docs/guides/try-on-open-source.md`
+
+**Step 1: Write the guide skeleton**
+
+Create the file with the title, intro paragraph, and all section headers:
+
+```markdown
+# Try Gavel on Open Source Code
+
+By the end of this guide you will have run Gavel on three open-source repositories
+in Go, Python, and JavaScript — using all three input modes.
+
+## Prerequisites
+
+## Example 1: Go — Directory Scan
+
+## Example 2: Python — File-Targeted Scan
+
+## Example 3: JavaScript — Diff Scan
+
+## What's Next
+```
+
+**Step 2: Write the Prerequisites section**
+
+Content:
+- Gavel binary installed (link to releases page and README installation section)
+- An LLM provider configured (link to Supported Providers in README)
+
+**Step 3: Write the provider setup**
+
+Provider table matching the CI guide style:
+
+| Priority | Provider | Model | Setup |
+|----------|----------|-------|-------|
+| Free/local | Ollama | `qwen2.5-coder:7b` | `ollama pull qwen2.5-coder:7b` |
+| Easy cloud | OpenRouter | `google/gemini-2.0-flash-exp` | API key from openrouter.ai |
+| Best quality | Anthropic | `claude-haiku-4-5` | API key from console.anthropic.com |
+
+Then show the three `.gavel/policies.yaml` variants (Ollama, OpenRouter, Anthropic) that the user will create in each example. Since every example uses the same config, show it once here and reference it from each example.
+
+**Step 4: Commit**
+
+```bash
+git add docs/guides/try-on-open-source.md
+git commit -m "docs: add skeleton and prerequisites for try-on-open-source guide"
+```
+
+---
+
+### Task 3: Write Example 1 — Go directory scan
+
+**Files:**
+- Modify: `docs/guides/try-on-open-source.md`
+
+**Step 1: Write the clone + configure steps**
+
+```markdown
+## Example 1: Go — Directory Scan
+
+This example scans an entire Go web application for security and code quality issues.
+
+### Clone the repository
+
+\```bash
+git clone https://github.com/0c34/govwa.git
+cd govwa
+\```
+
+### Configure Gavel
+
+\```bash
+mkdir -p .gavel
+\```
+
+Then create `.gavel/policies.yaml` using the provider config from Prerequisites above.
+```
+
+**Step 2: Write the run command**
+
+```markdown
+### Run the analysis
+
+\```bash
+gavel analyze --dir .
+\```
+```
+
+**Step 3: Write the annotated output walkthrough**
+
+Show a realistic sample verdict JSON with annotations explaining each field:
+- `decision` — what it means
+- `reason` — summary
+- `relevant_findings` — walk through 2-3 findings with their `gavel/confidence`, `gavel/explanation`, `gavel/recommendation`
+
+Include a note: "Your exact findings may differ — the important thing is the workflow."
+
+Use findings based on what the research in Task 1 reveals. If research hasn't happened yet, use plausible examples based on the known rule set (S3649 SQL injection, S2068 hardcoded credentials, S1086 error-ignored).
+
+**Step 4: Write the "dig deeper" subsection**
+
+Show how to find the full SARIF output:
+
+```markdown
+### Dig deeper
+
+The full SARIF report is in `.gavel/results/`. Find the latest run:
+
+\```bash
+ls -t .gavel/results/ | head -1
+\```
+
+Open the `sarif.json` file to see all findings with full detail.
+```
+
+**Step 5: Write the persona switching subsection**
+
+```markdown
+### Try a different persona
+
+Re-run the analysis with the security-focused persona:
+
+\```bash
+gavel analyze --dir . --persona security
+\```
+
+Compare the findings — the security persona emphasizes OWASP Top 10 vulnerabilities
+and authentication issues.
+```
+
+**Step 6: Commit**
+
+```bash
+git add docs/guides/try-on-open-source.md
+git commit -m "docs: add Example 1 (Go directory scan) to try-on-open-source guide"
+```
+
+---
+
+### Task 4: Write Example 2 — Python file-targeted scan
+
+**Files:**
+- Modify: `docs/guides/try-on-open-source.md`
+
+**Step 1: Write the clone + configure steps**
+
+```markdown
+## Example 2: Python — File-Targeted Scan
+
+Instead of scanning an entire directory, target specific files you care about.
+
+### Clone the repository
+
+\```bash
+git clone https://github.com/OWASP/PyGoat.git
+cd PyGoat
+\```
+
+### Configure Gavel
+
+\```bash
+mkdir -p .gavel
+\```
+
+Create `.gavel/policies.yaml` (same as Example 1).
+```
+
+**Step 2: Write the run command with specific files**
+
+Use the files identified in Task 1 research. Example:
+
+```markdown
+### Run the analysis
+
+\```bash
+gavel analyze --files introduction/views.py,authentication/views.py
+\```
+
+The `--files` flag takes a comma-separated list of file paths relative to the current directory.
+```
+
+**Step 3: Write the annotated output walkthrough**
+
+Similar structure to Example 1 but shorter (no persona switching). Highlight different finding types — e.g., TODO comments (S1135), long functions (AST001), hardcoded credentials (S2068).
+
+**Step 4: Commit**
+
+```bash
+git add docs/guides/try-on-open-source.md
+git commit -m "docs: add Example 2 (Python file scan) to try-on-open-source guide"
+```
+
+---
+
+### Task 5: Write Example 3 — JavaScript diff scan
+
+**Files:**
+- Modify: `docs/guides/try-on-open-source.md`
+
+**Step 1: Write the clone + configure steps**
+
+```markdown
+## Example 3: JavaScript — Diff Scan
+
+Analyze only the lines that changed — just like Gavel does in CI.
+
+### Clone the repository
+
+\```bash
+git clone https://github.com/gothinkster/node-express-realworld-example-app.git
+cd node-express-realworld-example-app
+\```
+
+### Configure Gavel
+
+\```bash
+mkdir -p .gavel
+\```
+
+Create `.gavel/policies.yaml` (same as before).
+```
+
+**Step 2: Write the diff generation and scan**
+
+```markdown
+### Generate a diff
+
+Pick a range of commits to analyze:
+
+\```bash
+git log --oneline -10
+\```
+
+Generate a patch file from a commit range:
+
+\```bash
+git diff HEAD~3..HEAD > changes.patch
+\```
+
+### Run the analysis
+
+\```bash
+gavel analyze --diff changes.patch
+\```
+
+You can also pipe directly from git:
+
+\```bash
+git diff HEAD~3..HEAD | gavel analyze --diff -
+\```
+```
+
+**Step 3: Write the annotated output walkthrough**
+
+Shorter than Example 1. Emphasize that diff mode only analyzes changed lines, making it fast and focused — exactly what happens in CI.
+
+**Step 4: Commit**
+
+```bash
+git add docs/guides/try-on-open-source.md
+git commit -m "docs: add Example 3 (JS diff scan) to try-on-open-source guide"
+```
+
+---
+
+### Task 6: Write the What's Next section
+
+**Files:**
+- Modify: `docs/guides/try-on-open-source.md`
+
+**Step 1: Write the section**
+
+```markdown
+## What's Next
+
+- **[Gate PRs with AI Code Review](ci-pr-gating.md)** — Automate Gavel in your CI pipeline with GitHub Actions
+- **[See Findings in Your Editor](editor-integration.md)** — View findings inline in VS Code or Neovim
+- **[Custom Rules](../../README.md#custom-rules)** — Write your own analysis rules
+- **[Personas](../../README.md#personas)** — Switch between code-reviewer, architect, and security perspectives
+```
+
+**Step 2: Commit**
+
+```bash
+git add docs/guides/try-on-open-source.md
+git commit -m "docs: add What's Next section to try-on-open-source guide"
+```
+
+---
+
+### Task 7: Add guide link to README.md
+
+**Files:**
+- Modify: `README.md`
+
+**Step 1: Add the link**
+
+In the `## Guides` section of `README.md` (line 73-76), add the new guide as the first entry (since it's the "start here" guide):
+
+```markdown
+## Guides
+
+- **[Try Gavel on Open Source Code](docs/guides/try-on-open-source.md)** — Run Gavel on real repositories in Go, Python, and JavaScript
+- **[Gate PRs with AI Code Review](docs/guides/ci-pr-gating.md)** — Set up GitHub Actions to automatically analyze every PR
+- **[See Findings in Your Editor](docs/guides/editor-integration.md)** — View Gavel findings inline in VS Code or Neovim
+```
+
+**Step 2: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: add try-on-open-source guide link to README"
+```
+
+---
+
+### Task 8: Final review pass
+
+**Step 1: Read the complete guide**
+
+Read `docs/guides/try-on-open-source.md` end-to-end and check:
+- All links work (relative paths are correct)
+- Provider configs are consistent across examples
+- Sample output is plausible
+- Tone matches existing guides
+- No broken markdown
+
+**Step 2: Fix any issues found**
+
+**Step 3: Commit fixes if any**
+
+```bash
+git add docs/guides/try-on-open-source.md
+git commit -m "docs: polish try-on-open-source guide"
+```


### PR DESCRIPTION
## Summary

- New onboarding tutorial at `docs/guides/try-on-open-source.md` walking users through running Gavel on three public OSS repos
- Covers all three input modes: `--dir` (Go), `--files` (Python), `--diff` (TypeScript)
- Includes provider setup for Ollama/OpenRouter/Anthropic, annotated sample output, troubleshooting, and persona switching
- Adds guide link as first entry in README Guides section

## Test plan

- [ ] Verify all relative links resolve correctly (ci-pr-gating.md, editor-integration.md, README anchors)
- [ ] Verify repo URLs are valid (`0c34/govwa`, `adeyosemanputra/pygoat`, `gothinkster/node-express-realworld-example-app`)
- [ ] Spot-check sample JSON output matches actual Gavel verdict format
- [ ] Confirm markdown renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)