### PR TITLE
ci: add Gavel self-analysis workflow for merge gating and benchmarking

### DIFF
--- a/.agents/skills/gitbutler/SKILL.md
+++ b/.agents/skills/gitbutler/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: but
+version: 0.19.1
+description: "Commit, push, branch, and manage version control with GitButler. Use for: commit my changes, check what changed, create a PR, push my branch, view diff, create branches, stage files, edit commit history, squash commits, amend commits, undo commits, pull requests, merge, stash work. Replaces git - use 'but' instead of git commit, git status, git push, git checkout, git add, git diff, git branch, git rebase, git stash, git merge. Covers all git, version control, and source control operations."
+author: GitButler Team
+---
+
+# GitButler CLI Skill
+
+Use GitButler CLI (`but`) as the default version-control interface.
+
+## Non-Negotiable Rules
+
+1. Use `but` for all write operations. Never run `git add`, `git commit`, `git push`, `git checkout`, `git merge`, `git rebase`, `git stash`, or `git cherry-pick`.
+2. Start every write/history-edit task with `but status --json`.
+3. For mutation commands, always add `--json --status-after`.
+4. Use CLI IDs from `but status --json` / `but diff --json` / `but show --json`; do not hardcode IDs and do not switch branches with `git checkout`.
+5. After a successful mutation with `--status-after`, do not run a redundant `but status` unless needed for new IDs.
+6. If the user says a `git` write command (for example "git push"), translate it to the `but` equivalent and execute the `but` command directly.
+7. For branch-update tasks, run `but pull --check --json` before `but pull --json --status-after`. Do not substitute `but fetch` + status summaries for this check.
+8. Avoid routine `--help` probes before mutations. Use the command patterns in this skill (and `references/reference.md`) first; only use `--help` when syntax is genuinely unclear or after a failed attempt.
+
+## Core Flow
+
+```bash
+but status --json
+# If new branch needed:
+but branch new <name>
+# Perform task with IDs from status/diff/show
+but <mutation> ... --json --status-after
+```
+
+## Canonical Command Patterns
+
+- Commit specific files/hunks:
+  `but commit <branch> -m "<message>" --changes <id>,<id> --json --status-after`
+- Create branch while committing:
+  `but commit <branch> -c -m "<message>" --changes <id> --json --status-after`
+- Amend into a known commit:
+  `but amend <file-id> <commit-id> --json --status-after`
+- Reorder commits:
+  `but move <source-commit-id> <target-commit-id> --json --status-after`
+- Push:
+  `but push`
+  or
+  `but push <branch-id>`
+- Pull update safety flow:
+  `but pull --check --json`
+  then
+  `but pull --json --status-after`
+
+## Task Recipes
+
+### Commit one file
+
+1. `but status --json`
+2. Find that file's `cliId`
+3. `but commit <branch> -c -m "<clear message>" --changes <file-id> --json --status-after`
+
+### Commit only A, not B
+
+1. `but status --json`
+2. Find `src/a.rs` ID and `src/b.rs` ID
+3. Commit with `--changes <a-id>` only
+
+### User says "git push"
+
+Interpret as GitButler push. Run `but push` (or `but push <branch-id>`) immediately.
+Do not run `git push`, even if `but push` reports nothing to push.
+
+### Check mergeability, then update branches
+
+1. Run exactly: `but pull --check --json`
+2. If user asked to proceed, run: `but pull --json --status-after`
+3. Do not replace step 1 with `but fetch`, `but status`, or a narrative-only summary.
+
+### Amend into existing commit
+
+1. `but status --json`
+2. Locate file ID and commit ID from `status` (or `but show <branch-id> --json`)
+3. Run exactly: `but amend <file-id> <commit-id> --json --status-after`
+4. Never use `git checkout` or `git commit --amend`
+
+### Reorder commits
+
+1. `but status --json`
+2. Identify source/target commit IDs in the branch by commit message
+3. Run: `but move <commit-a> <commit-b> --json --status-after`
+4. From the returned `status`, refresh IDs and then run the inverse move:
+   `but move <commit-b> <commit-a> --json --status-after`
+5. This two-step sequence is the safe default for reorder requests.
+6. Never use `git rebase` for this.
+
+## Git-to-But Map
+
+- `git status` -> `but status --json`
+- `git add` + `git commit` -> `but commit ... --changes ... --json --status-after`
+- `git checkout -b` -> `but branch new <name>`
+- `git push` -> `but push`
+- `git rebase -i` -> `but move`, `but squash`, `but reword`
+- `git cherry-pick` -> `but pick`
+
+## Notes
+
+- Prefer explicit IDs over file paths for mutations.
+- `--changes` is the safe default for precise commits.
+- `--changes` accepts one argument per flag. For multiple IDs, use comma-separated values (`--changes a1,b2`) or repeat the flag (`--changes a1 --changes b2`), not `--changes a1 b2`.
+- Read-only git inspection is allowed (`git log`, `git blame`) when needed.
+- Keep skill version checks low-noise:
+  - Do not run `but skill check` as a routine preflight on every task.
+  - Run `but skill check` when command behavior appears to diverge from this skill (for example: unexpected unknown-flag errors, missing subcommands, or output shape mismatches), or when the user asks.
+  - If update is available, recommend `but skill check --update` (or run it if the user asked to update).
+- For deeper command syntax and flags, use `references/reference.md`.
+- For workspace model and dependency behavior, use `references/concepts.md`.
+- For end-to-end workflow patterns, use `references/examples.md`.

--- a/.agents/skills/gitbutler/references/concepts.md
+++ b/.agents/skills/gitbutler/references/concepts.md
@@ -1,0 +1,353 @@
+# GitButler CLI Key Concepts
+
+Deep dive into GitButler's conceptual model and philosophy.
+
+## The Workspace Model
+
+### Traditional Git: Serial Branching
+
+```
+main ──┬── feature-a (checkout here, work, commit, checkout back)
+       └── feature-b (checkout here, work, commit, checkout back)
+```
+
+- Work on ONE branch at a time
+- Switch contexts with `git checkout`
+- Changes are isolated by branch
+
+### GitButler: Parallel Stacks
+
+```
+workspace (gitbutler/workspace)
+  ├─ feature-a (applied, merged into workspace)
+  ├─ feature-b (applied, merged into workspace)
+  └─ feature-c (unapplied, not in workspace)
+```
+
+- Work on MULTIPLE branches simultaneously
+- No context switching - all applied branches merged in working directory
+- Changes are ASSIGNED to branches, not isolated by checkout
+
+### Key Implications
+
+1. **No `git checkout`**: You don't switch between branches. All applied branches exist simultaneously in your workspace.
+
+2. **Multiple staging areas**: Each branch is like having its own `git add` staging area. You stage files to specific branches.
+
+3. **The `gitbutler/workspace` branch**: A merge commit containing all applied stacks. Don't interact with it directly - use `but` commands.
+
+4. **Applied vs Unapplied**: Control which branches are active:
+   - Applied branches: In your working directory
+   - Unapplied branches: Exist but not active
+   - Use `but apply`/`but unapply` to control
+
+## CLI IDs: Short Identifiers
+
+Every object gets a short, human-readable CLI ID shown in `but status`. IDs are generated per-session and are unique across all entity types (no two objects share an ID) — always read them from `but status --json`.
+
+```
+Commits:    1b, 8f, c2     (short hex prefixes of the SHA, long enough to be unique)
+Branches:   fe, bu, ui     (unique 2–3 char substring of the branch name, e.g. "fe" from "feature-x";
+                             falls back to auto-generated ID if no unique substring exists)
+Files:      g0, h0, i0     (auto-generated, 2–3 chars)
+Hunks:      j0, k1, l2     (auto-generated, 2–3 chars)
+Stacks:     m0, n0          (auto-generated, 2–3 chars)
+```
+
+**Why?** Git commit SHAs are long (40 chars). CLI IDs are short (2-3 chars) and unique within your current workspace context.
+
+**Usage:** Pass these IDs as arguments to commands:
+
+```bash
+but commit <branch-id> -m "message"      # Commit to branch
+but stage <file-id> <branch-id>          # Stage file to branch
+but rub <commit-id> <commit-id>          # Squash commits
+```
+
+## Parallel vs Stacked Branches
+
+### Parallel Branches (Independent Work)
+
+Create with `but branch new <name>`:
+
+```
+main ──┬── api-endpoint (independent)
+       └── ui-update    (independent)
+```
+
+Use when:
+
+- Tasks don't depend on each other
+- Can be merged independently
+- No shared code between them
+
+Example: Adding a new API endpoint and updating button styles are independent.
+
+### Stacked Branches (Dependent Work)
+
+Create with `but branch new <name> -a <anchor>`:
+
+```
+main ── authentication ── user-profile ── settings-page
+        (base)            (stacked)       (stacked)
+```
+
+Use when:
+
+- Feature B needs code from Feature A
+- Building incrementally on previous work
+- Creating a series of related changes
+
+Example: User profile page needs authentication to be implemented first.
+
+**Dependency tracking:** GitButler automatically tracks which changes depend on which commits. You can't stage dependent changes to the wrong branch.
+
+## Multiple Staging Areas
+
+Traditional git has ONE staging area:
+
+```bash
+git add file1.js    # Stage to THE staging area
+git add file2.js    # Stage to THE staging area
+git commit          # Commit from THE staging area
+```
+
+GitButler has MULTIPLE staging areas (one per branch):
+
+```bash
+but stage file1.js api-branch    # Stage to api-branch's staging area
+but stage file2.js ui-branch     # Stage to ui-branch's staging area
+but commit api-branch -m "..."   # Commit from api-branch's staging area
+but commit ui-branch -m "..."    # Commit from ui-branch's staging area
+```
+
+**Unstaged changes:** Files not staged to any branch yet. Use `but status` to see them, then `but stage` to assign them.
+
+**Auto-assignment:** If only one branch is applied, changes may auto-assign to it.
+
+## The `but rub` Philosophy
+
+`but rub` is the core primitive operation: "rub two things together" to perform an action.
+
+### What Happens Based on Types
+
+The operation performed depends on what you combine:
+
+```
+SOURCE ↓ / TARGET →  │ zz (unassigned) │ Commit     │ Branch      │ Stack
+─────────────────────┼─────────────────┼────────────┼─────────────┼────────────
+File/Hunk            │ Unstage         │ Amend      │ Stage       │ Stage
+Commit               │ Undo            │ Squash     │ Move        │ -
+Branch (all changes) │ Unstage all     │ Amend all  │ Reassign    │ Reassign
+Stack (all changes)  │ Unstage all     │ -          │ Reassign    │ Reassign
+Unassigned (zz)      │ -               │ Amend all  │ Stage all   │ Stage all
+File-in-Commit       │ Uncommit        │ Move       │ Uncommit & assign │ -
+```
+
+`zz` is a special target meaning "unassigned" (no branch).
+
+**Common examples:**
+
+| Source | Target | Operation | Example |
+|--------|--------|-----------|---------|
+| File | Branch | Stage file to branch | `but rub a1 bu` |
+| File | Commit | Amend file into commit | `but rub a1 c3` |
+| Commit | Commit | Squash commits | `but rub c2 c3` |
+| Commit | Branch | Move commit to branch | `but rub c2 bu` |
+| File | `zz` | Unstage file | `but rub a1 zz` |
+| Commit | `zz` | Undo commit | `but rub c2 zz` |
+| `zz` | Branch | Stage all unassigned | `but rub zz bu` |
+
+### Higher-Level Conveniences
+
+These commands are wrappers around `but rub`:
+
+- `but stage <file> <branch>` = `but rub <file> <branch>`
+- `but amend <file> <commit>` = `but rub <file> <commit>`
+- `but squash` = Multiple `but rub <commit> <commit>` operations
+- `but move` = `but rub <commit> <target>` with position control
+
+**Why this design?** One powerful primitive is easier to understand and maintain than many specialized commands. Once you understand `but rub`, you understand the editing model.
+
+## Dependency Tracking
+
+GitButler tracks dependencies between changes automatically.
+
+### How It Works
+
+```
+Commit C1: Added function foo()
+Commit C2: Added function bar()
+Uncommitted: Call to foo() in new code
+```
+
+The uncommitted change **depends on** C1 (because it calls `foo()`).
+
+**Implications:**
+
+1. Can't stage this change to a branch that doesn't have C1
+2. `but absorb` will automatically amend it into C1 (or a commit after C1)
+3. If you try to move the change, GitButler prevents invalid operations
+
+### Why This Matters
+
+Prevents you from creating broken states:
+
+- Can't move dependent code away from its dependencies
+- Can't stage changes to wrong branches
+- Ensures each branch remains independently functional
+
+## Empty Commits as Placeholders
+
+You can create empty commits:
+
+```bash
+but commit empty --before c3
+but commit empty --after c3
+```
+
+**Use cases:**
+
+1. **Mark future work:** Create empty commit as placeholder for changes you'll make
+2. **Mark targets:** Use with `but mark <empty-commit-id>` so future changes auto-amend into it
+3. **Organize history:** Add semantic markers in commit history
+
+Example workflow:
+
+```bash
+but commit empty -m "TODO: Add error handling" --before c5
+but mark <empty-commit-id>
+# Now work on error handling, changes auto-amend into the placeholder
+```
+
+## Auto-Staging and Auto-Commit (Marks)
+
+Set a "mark" on a branch or commit to automatically organize new changes.
+
+### Mark a Branch
+
+```bash
+but mark <branch-id>
+```
+
+New unstaged changes automatically stage to this branch. Useful when focused on one feature.
+
+### Mark a Commit
+
+```bash
+but mark <commit-id>
+```
+
+New changes automatically amend into this commit. Useful for iterative refinement.
+
+### Remove Marks
+
+```bash
+but mark <id> --delete    # Remove specific mark
+but unmark                # Remove all marks
+```
+
+**Example workflow:**
+
+```bash
+but branch new refactor
+but mark <refactor-branch-id>
+# Make lots of changes - they all auto-stage to refactor branch
+but unmark
+```
+
+## Operation History (Oplog)
+
+Every operation in GitButler is recorded in the oplog (operation log).
+
+### What Gets Recorded
+
+- Branch creation/deletion
+- Commits
+- Stage operations
+- Rub/squash/move operations
+- Push/pull operations
+
+### Using Oplog
+
+```bash
+but oplog                      # View history
+but undo                       # Undo last operation
+but oplog restore <snapshot-id>  # Restore to specific point
+```
+
+Think of it as "git reflog" but for all GitButler operations, not just branch movements.
+
+**Safety net:** Made a mistake? `but undo` it. Experimented and want to go back? `but oplog restore` to earlier snapshot.
+
+## Applied vs Unapplied Branches
+
+Branches can be in two states:
+
+### Applied Branches
+
+- Active in your workspace
+- Merged into `gitbutler/workspace`
+- Changes visible in working directory
+- Can make changes, commit, stage files
+
+### Unapplied Branches
+
+- Exist but not active
+- Not in working directory
+- Can't make changes (must apply first)
+- Useful for temporarily setting aside work
+
+### Controlling State
+
+```bash
+but apply <id>             # Make branch active
+but unapply <id>           # Make branch inactive
+```
+
+**Use cases:**
+
+- Unapply branches causing conflicts
+- Focus on subset of work (unapply others)
+- Temporarily set aside work without deleting
+
+## Conflict Resolution Mode
+
+When `but pull` causes conflicts, affected commits are marked as conflicted.
+
+### Resolution Workflow
+
+1. **Identify:** `but status` shows conflicted commits
+2. **Enter mode:** `but resolve <commit-id>`
+3. **Fix conflicts:** Edit files, remove conflict markers
+4. **Check:** `but resolve status` shows remaining conflicts
+5. **Finalize:** `but resolve finish` or `but resolve cancel`
+
+### During Resolution
+
+- You're in a special mode focused on that commit
+- Other GitButler operations are limited
+- `but status` shows you're in resolution mode
+- Must finish or cancel before continuing normal work
+
+## Read-Only Git Commands
+
+Git commands that don't modify state are safe to use:
+
+**Safe (read-only):**
+
+- `git log` - View history
+- `git diff` - See changes (but prefer `but diff` — it supports CLI IDs and `--json`)
+- `git show` - View commits
+- `git blame` - See line history
+- `git reflog` - View reference log
+
+**Don't use in a GitButler workspace:**
+
+- `git status` - Misleading: shows merged workspace state, not individual stacks; missing CLI IDs that agents need
+- `git commit` - Commits to wrong place (bypasses branch assignment)
+- `git checkout` - Breaks workspace model
+- `git rebase` - Conflicts with GitButler's management
+- `git merge` - Use `but merge` instead
+
+**Rule of thumb:** If it reads, it's fine. If it writes, use `but` instead.

--- a/.agents/skills/gitbutler/references/examples.md
+++ b/.agents/skills/gitbutler/references/examples.md
@@ -1,0 +1,508 @@
+# GitButler CLI Workflow Examples
+
+Real-world examples of common workflows.
+
+**Note on CLI IDs:** Examples below use illustrative IDs like `bu`, `c3`, `a1` to keep commands readable. In practice, **always read actual IDs from `but status --json`** — they are generated per-session and will differ from these examples. Branch IDs are derived from unique substrings of the branch name (e.g., `fe` from `feature-x`), commit IDs use short hex prefixes (e.g., `1b`, `8f`), and file/hunk/stack IDs are auto-generated (e.g., `g0`, `h0`). All IDs are unique across entity types.
+
+## Example 1: Starting Independent Parallel Work
+
+**Scenario:** Need to work on two independent features: a new API endpoint and UI styling updates.
+
+```bash
+# 1. Check current state
+but status --json
+
+# 2. Create two independent (parallel) branches
+but branch new api-endpoint
+but branch new ui-styling
+
+# 3. Make changes to multiple files
+# (edit api/users.js and components/Button.svelte)
+
+# 4. Check what's unstaged
+but status --json
+
+# 5. Commit specific files directly using --changes (recommended for agents)
+# Use cliId values from but status --json output (e.g., branch IDs and file IDs)
+# For multiple IDs, use one comma-separated argument or repeat --changes.
+but commit <api-branch-id> -m "Add user details endpoint" --changes <api-file-id> --json --status-after
+but commit <ui-branch-id> -m "Update button hover styles" --changes <ui-file-id> --json --status-after
+
+# Alternative: stage first, then commit with --only
+# but stage <api-file-id> <api-branch-id> && but stage <ui-file-id> <ui-branch-id>
+# but commit <api-branch-id> --only -m "Add user details endpoint" --json --status-after
+# but commit <ui-branch-id> --only -m "Update button hover styles" --json --status-after
+
+# 6. Push branches independently (optional, can skip if using pr new)
+but push <api-branch-id> --json
+but push <ui-branch-id> --json
+
+# 7. Create pull requests (auto-pushes if not already pushed)
+but pr new <api-branch-id> --json
+but pr new <ui-branch-id> --json
+```
+
+**Why parallel branches?** The API endpoint and UI styling are independent - neither depends on the other. They can be reviewed and merged separately.
+
+## Example 2: Building Stacked Features
+
+**Scenario:** Need to add authentication, then build a user profile page that requires auth.
+
+```bash
+# 1. Check current state and update
+but pull --json
+but status --json
+
+# 2. Create base branch for authentication
+but branch new add-authentication
+
+# 3. Implement auth and commit
+# (edit auth/login.js, auth/middleware.js)
+but status --json
+but stage <file-ids> bu --json --status-after  # Stage changes to auth branch
+but commit bu --only -m "Add JWT authentication" --json --status-after
+
+# 4. Create stacked branch anchored on authentication
+but branch new user-profile -a bu
+
+# 5. Implement profile page (depends on auth)
+# (edit pages/profile.js)
+but status --json
+but stage <file-ids> bv --json --status-after  # Stage changes to profile branch
+but commit bv --only -m "Add user profile page" --json --status-after
+
+# 6. Push both branches (maintains stack relationship)
+but push --json
+```
+
+**Result:** Two PRs where user-profile PR depends on authentication PR. GitHub/GitLab shows the dependency.
+
+## Example 3: Using Absorb Instead of New Commits
+
+**Scenario:** Made a small typo fix that should be part of the last commit, not a new commit.
+
+```bash
+# 1. Check current commits and unstaged changes
+but status --json
+
+# Output shows:
+# Branch: feature-x (bu)
+# Commits:
+#   c3: Implement feature logic
+#   c2: Add feature tests
+# Unstaged:
+#   a1: fix-typo.js (staged to bu)
+
+# 2. Preview what absorb would do (recommended first step)
+but absorb a1 --dry-run --json    # Shows where a1 would be absorbed
+
+# 3. Absorb the specific file into appropriate commit
+but absorb a1 --json --status-after    # Absorb just this file + get updated status
+
+# GitButler analyzes the change and amends it into c3
+# (because the typo is in code from c3)
+```
+
+**Targeted vs blanket absorb:**
+
+```bash
+but absorb a1 --json --status-after    # Absorb specific file (recommended)
+but absorb bu --json --status-after    # Absorb all changes staged to branch bu
+but absorb --json --status-after       # Absorb ALL uncommitted changes (use with caution)
+```
+
+**Why absorb?** Keeps history clean. Small fixes belong in the commits they fix, not as separate "fix typo" commits.
+
+## Example 4: Reorganizing Commit History
+
+### Scenario A: Squashing Commits
+
+**Situation:** Made 5 small WIP commits, want to combine into one logical commit.
+
+```bash
+# Before:
+# c5: More tweaks
+# c4: Fix another thing
+# c3: Fix tests
+# c2: Adjust logic
+# c1: Initial implementation
+
+# Squash all commits in branch
+but squash bu --json --status-after
+
+# Or squash specific range
+but squash c2..c5 --json --status-after    # Squashes c2, c3, c4, c5 into one
+
+# Or squash specific commits
+but squash c2 c3 c4 --json --status-after    # Squashes these three
+```
+
+### Scenario B: Moving Files Between Commits
+
+**Situation:** A file was committed in the wrong commit, need to move it.
+
+```bash
+# 1. See which files are in which commits
+but status --json -f
+
+# Output shows:
+# c3: api.js, utils.js
+# c2: config.js
+
+# 2. Move utils.js from c3 to c2
+but rub a2 c2 --json --status-after    # File a2 (utils.js) → commit c2 + get updated status
+```
+
+### Scenario C: Moving Commit to Different Branch
+
+**Situation:** Committed to wrong branch, need to move commit.
+
+```bash
+# 1. Check current state
+but status --json
+
+# Output:
+# Branch: feature-a (bu)
+#   c3: This should be in feature-b!
+#   c2: Correct commit
+
+# 2. Create or identify target branch
+but branch new feature-b    # Creates branch bv
+
+# 3. Move the commit
+but move c3 bv --json --status-after    # Move c3 to top of branch bv
+```
+
+## Example 5: Using Marks for Focused Work
+
+**Scenario:** Working on a large refactor, want all changes to automatically stage to that branch.
+
+```bash
+# 1. Create refactor branch
+but branch new refactor
+
+# 2. Mark it for auto-staging
+but mark bu    # Branch bu (refactor) is now marked
+
+# 3. Make changes across many files
+# (edit 20 different files)
+
+# 4. All changes automatically staged to refactor branch
+but status --json  # Shows all changes staged to bu
+
+# 5. Commit the staged changes
+but commit bu --only -m "Refactor error handling across app" --json --status-after
+
+# 6. Remove mark
+but unmark
+```
+
+**Alternative: Mark a commit for auto-amend**
+
+```bash
+# 1. Create empty commit as placeholder
+but commit empty -m "TODO: Add error handling"
+
+# 2. Mark it
+but mark c5    # Commit c5 is now marked
+
+# 3. Make changes - they auto-amend into c5
+# (edit files)
+
+# 4. Check result
+but show c5 --json    # Shows accumulated changes
+
+# 5. Remove mark when done
+but unmark
+```
+
+## Example 6: Conflict Resolution
+
+**Scenario:** After `but pull`, conflicts appear in a commit.
+
+```bash
+# 1. Pull updates
+but pull --json
+
+# Output:
+# Conflict in commit c3 on branch feature-x
+
+# 2. Check status
+but status --json
+
+# Output:
+# Branch: feature-x (bu)
+#   c3: Add validation (CONFLICTED)
+
+# 3. Enter resolution mode
+but resolve c3
+
+# Output:
+# Entering resolution mode for commit c3
+# Fix conflicts in: api/users.js, api/validation.js
+
+# 4. Edit files to resolve conflicts
+# (open files, remove <<< === >>> markers)
+
+# 5. Check progress
+but resolve status
+
+# Output:
+# Remaining conflicts:
+#   api/validation.js
+
+# 6. Continue fixing...
+# (resolve last conflict)
+
+# 7. Finalize
+but resolve finish
+
+# Back to normal workspace mode
+```
+
+## Example 7: Complete Feature Development Workflow
+
+**Scenario:** Building a complete feature from start to finish.
+
+```bash
+# 1. Update to latest
+but pull --json
+
+# 2. Create branch for feature
+but branch new user-dashboard
+
+# 3. Make initial changes
+# (create dashboard.js, add routes)
+
+# 4. Check and stage
+but status --json
+but stage <file-ids> bu --json --status-after  # Stage changes to dashboard branch
+
+# 5. First commit
+but commit bu --only -m "Add dashboard route and basic layout" --json --status-after
+
+# 6. Continue iterating
+# (add widgets, styling)
+but stage <file-ids> bu --json --status-after
+but commit bu --only -m "Add dashboard widgets" --json --status-after
+but stage <file-ids> bu --json --status-after
+but commit bu --only -m "Style dashboard components" --json --status-after
+
+# 7. Make small fix
+# (fix typo in widget)
+but absorb a1 --json --status-after    # Absorb specific file into appropriate commit
+
+# 8. Clean up if needed
+but squash bu --json --status-after    # Combine all commits (optional)
+
+# 9. Push to remote (can also skip - pr new auto-pushes)
+but push bu --json
+
+# 10. Create pull request
+but pr new bu --json
+
+# Output:
+# Created PR #123: https://github.com/org/repo/pull/123
+
+# 11. After PR is merged, update
+but pull --json
+```
+
+## Example 8: Working with Applied/Unapplied Branches
+
+**Scenario:** Have 3 branches, but two are causing conflicts. Temporarily unapply them.
+
+```bash
+# 1. Check active branches
+but status --json
+
+# Output:
+# Applied branches:
+#   bu: feature-a
+#   bv: feature-b
+#   bw: feature-c
+
+# 2. Conflicts between feature-b and feature-c
+# Unapply them temporarily
+but unapply bv
+but unapply bw
+
+# 3. Focus on feature-a
+# (make changes, stage, commit)
+but stage <file-ids> bu --json --status-after
+but commit bu --only -m "Complete feature-a" --json --status-after
+
+# 4. Create PR for feature-a (auto-pushes)
+but pr new bu --json
+
+# 5. Reapply other branches
+but apply bv
+but apply bw
+
+# 6. Deal with their conflicts now
+but resolve ...
+```
+
+## Example 9: Fixing History Before Pushing
+
+**Scenario:** Made several commits, realized you need to reword messages and reorder.
+
+```bash
+# 1. Current state
+but status --json
+
+# Output:
+# Branch: feature-x (bu)
+#   c5: final commit
+#   c4: WIP
+#   c3: Fix stuff
+#   c2: Another fix
+#   c1: Initial
+
+# 2. Reword commit messages
+but reword c4 -m "Add validation logic"
+but reword c3 -m "Fix edge case in parser"
+but reword c2 -m "Update error messages"
+
+# 3. Move c5 to be earlier
+but move c5 c3 --json --status-after    # Move c5 before c3
+
+# 4. Squash similar commits
+but squash c2 c3 --json --status-after    # Combine error handling commits
+
+# Output:
+# Branch: feature-x (bu)
+#   c4: Add validation logic
+#   c3: final commit
+#   c2: Fix edge case in parser and update error messages
+#   c1: Initial
+
+# 5. Push clean history
+but push bu --json
+```
+
+## Example 10: Daily Development Workflow
+
+**Typical day working with GitButler:**
+
+```bash
+# Morning: Start day
+but pull --json                   # Get latest from team
+
+# Start new task
+but branch new fix-auth-bug       # Create branch for today's work
+
+# Work and commit iteratively
+# (make changes)
+but status --json                 # Check changes
+but stage <file-ids> bu --json --status-after    # Stage to branch
+but commit bu --only -m "Identify auth bug source" --json --status-after
+# (make more changes)
+but stage <file-ids> bu --json --status-after    # Stage to branch
+but commit bu --only -m "Fix token expiration handling" --json --status-after
+# (small fix to existing code)
+but absorb a1 --json --status-after              # Absorb specific fix into appropriate commit
+
+# Mid-day: Start urgent fix on different branch
+but branch new hotfix-login       # Parallel branch for urgent work
+# (make fix)
+but stage <file-ids> bv --json --status-after    # Stage to hotfix branch
+but commit bv --only -m "Fix login redirect loop" --json --status-after
+but pr new bv --json              # Push and create PR immediately
+
+# Back to original work
+# (continue working on bu, auth bug fix)
+but stage <file-ids> bu --json --status-after    # Stage to auth branch
+but commit bu --only -m "Add tests for token handling" --json --status-after
+
+# End of day: Clean up and create PR
+but squash bu --json --status-after    # Combine into clean history
+but pr new bu --json              # Push and create PR
+
+# After PR review: Make requested changes
+# (make changes based on feedback)
+but absorb <file-id> --json --status-after    # Absorb specific changes into commits
+# Or absorb all changes for this branch:
+but absorb bu --json --status-after          # Absorb all changes staged to bu
+but push bu --with-force --json   # Force push updated history
+```
+
+## Example 11: Recovering from Mistakes
+
+**Scenario:** Made changes you didn't mean to, need to undo.
+
+### Undo Last Operation
+
+```bash
+# Made a mistake
+but squash bu    # Oops! Didn't mean to squash
+
+# Undo it
+but undo         # Reverts the squash
+```
+
+### Restore to Earlier Point
+
+```bash
+# View operation history
+but oplog --json
+
+# Output:
+# s5: squash branch bu
+# s4: commit bu "message"
+# s3: stage files to bu
+# s2: create branch bu
+# s1: pull from remote
+
+# Restore to before squash
+but oplog restore s4
+```
+
+### Discard Uncommitted Changes
+
+```bash
+# Changed a file but want to discard
+but status --json
+
+# Output:
+# Unstaged:
+#   a1: bad-changes.js
+
+# Discard it
+but discard a1
+```
+
+## Tips and Tricks
+
+### Quick Status Check
+
+```bash
+but status --json -f    # File-centric view for quick overview
+```
+
+### Preview Before Doing
+
+```bash
+but absorb <file-id> --dry-run --json  # See where specific file would be absorbed
+but push --dry-run --json              # See what would be pushed
+```
+
+### JSON for Scripting
+
+```bash
+but status --json | jq '.branches[] | .name'    # List branch names
+```
+
+### Auto-completion
+
+```bash
+eval "$(but completions zsh)"     # Add to ~/.zshrc
+eval "$(but completions bash)"    # Add to ~/.bashrc
+```
+
+### Viewing History
+
+```bash
+but show bu --json       # Show all commits in branch
+git log bu               # Traditional git log (read-only, still works)
+```

--- a/.agents/skills/gitbutler/references/reference.md
+++ b/.agents/skills/gitbutler/references/reference.md
@@ -1,0 +1,566 @@
+# GitButler CLI Command Reference
+
+Comprehensive reference for all `but` commands.
+
+## Contents
+
+- [Inspection](#inspection-understanding-state) - `status`, `show`, `diff`
+- [Branching](#branching) - `branch new`, `apply`, `unapply`, `branch delete`, `pick`
+- [Staging](#staging-multiple-staging-areas) - `stage`, `rub`
+- [Committing](#committing) - `commit`, `absorb`
+- [Editing History](#editing-history) - `rub`, `squash`, `amend`, `move`, `uncommit`, `reword`, `discard`
+- [Conflict Resolution](#conflict-resolution) - `resolve`
+- [Remote Operations](#remote-operations) - `push`, `pull`, `pr`, `merge`
+- [Automation](#automation) - `mark`, `unmark`
+- [History & Undo](#history--undo) - `undo`, `oplog`
+- [Setup & Configuration](#setup--configuration) - `setup`, `teardown`, `config`, `gui`, `update`, `alias`
+- [Global Options](#global-options)
+
+## Inspection (Understanding State)
+
+### `but status`
+
+Overview of workspace state - this is your entry point.
+
+```bash
+but status              # Human-readable view
+but status -f           # File-centric view (shows which files in which commits)
+but status --json       # Structured output for parsing
+but status --verbose    # Detailed information
+but status --upstream   # Show upstream relationship
+```
+
+Shows:
+
+- Applied/unapplied branches in workspace
+- Uncommitted changes (unstaged files)
+- Commits on each stack
+- CLI IDs to use in other commands
+
+### `but show <id>`
+
+Details about a commit or branch.
+
+```bash
+but show <id>           # Show details
+but show <id> --verbose # More detailed information
+but show <id> --json    # Structured output
+```
+
+### `but diff [target]`
+
+Display diff for file, branch, stack, or commit.
+
+```bash
+but diff <file-id>      # Diff for specific file
+but diff <branch-id>    # Diff for all changes in branch
+but diff <commit-id>    # Diff for specific commit
+but diff                # Diff for entire workspace
+but diff --json         # JSON output with hunk IDs for `but commit --changes`
+```
+
+**Hunk IDs in JSON output:** For uncommitted changes, `but diff --json` returns each hunk as a separate entry in `changes[]` with an `id` field (e.g., `e8`, `j0`). Pass these IDs to `but commit --changes` for fine-grained, hunk-level commits. For commit/branch diffs, `id` is absent — entries are per-file with hunks nested under `diff.hunks`.
+
+## Branching
+
+### `but branch`
+
+List all branches (default when no subcommand).
+
+```bash
+but branch              # List branches
+but branch --json       # JSON output
+but branch list [filter]  # Filter branches by name (case-insensitive substring)
+but branch list --no-ahead  # Skip commits-ahead calculation (faster)
+but branch list --no-check  # Skip clean-merge check (faster)
+but branch list -r      # Show only remote branches
+but branch list -l      # Show only local branches
+but branch list -a      # Show all branches (not just active + 20 most recent)
+but branch list --review  # Fetch and display PR/MR information
+```
+
+### `but branch new <name>`
+
+Create a new branch.
+
+```bash
+but branch new feature              # Independent branch (parallel work)
+but branch new feature -a <anchor>  # Stacked branch (dependent work)
+```
+
+Use parallel branches for independent tasks. Use stacked branches when work depends on another branch.
+
+### `but apply <id>`
+
+Activate a branch in the workspace.
+
+```bash
+but apply <id>           # Activate branch in workspace
+```
+
+Applied branches are merged into `gitbutler/workspace` and visible in working directory.
+
+### `but unapply <id>`
+
+Deactivate a branch from the workspace.
+
+```bash
+but unapply <id>         # Deactivate branch from workspace
+```
+
+The identifier can be a CLI ID pointing to a stack or branch, or a branch name. If a branch is specified, the entire stack containing that branch will be unapplied.
+
+### `but branch delete <id>`
+
+Delete a branch.
+
+```bash
+but branch delete <id>
+but branch -d <id>      # Short form
+```
+
+### `but branch show <id>`
+
+Show commits ahead of base for a branch.
+
+```bash
+but branch show <id>
+but branch show <id> -f       # Show files modified in each commit with line counts
+but branch show <id> --ai     # Generate AI summary of branch changes
+but branch show <id> --check  # Check if branch merges cleanly into upstream
+but branch show <id> -r       # Fetch and display review information (PRs/MRs)
+```
+
+### `but pick <source> [target]`
+
+Cherry-pick commits from unapplied branches into applied branches.
+
+```bash
+but pick <commit-sha> <branch>       # Pick specific commit into branch
+but pick <cli-id> <branch>           # Pick using CLI ID (e.g., "c5")
+but pick <unapplied-branch>          # Interactive commit selection from branch
+but pick <commit-sha>                # Auto-select target if only one branch
+```
+
+The source can be:
+- A commit SHA (full or short)
+- A CLI ID from `but status`
+- An unapplied branch name (shows interactive commit picker)
+
+If no target is specified and multiple branches exist, prompts for selection interactively.
+
+## Staging (Multiple Staging Areas)
+
+GitButler has multiple staging areas - one per stack.
+
+### `but stage <file> <branch>`
+
+Stage file to a specific branch.
+
+```bash
+but stage <file-id> <branch-id>
+but stage <file-id> <branch-id> --status-after  # Stage then show workspace status
+```
+
+Alias for `but rub <file> <branch>`. You can't stage changes that depend on branch A to branch B.
+
+### `but rub <file> <branch>`
+
+Core primitive for staging (see Editing History for other `but rub` uses).
+
+```bash
+but rub <file-id> <branch-id>    # Stage file to branch
+```
+
+## Committing
+
+### `but commit [branch]`
+
+Commit changes to a branch.
+
+```bash
+but commit <branch> --only -m "message"  # Commit ONLY staged changes (recommended)
+but commit <branch> -m "message"         # Commit ALL uncommitted changes to branch
+but commit <branch> -m "message" --changes <id>,<id>  # Commit specific files or hunks by CLI ID
+but commit <branch> -m "message" --changes <id> --changes <id>  # Alternative: repeat flag
+but commit <branch> --message-file msg.txt  # Read commit message from file
+but commit <branch> -i                   # AI-generated commit message
+but commit <branch> -i="fix the auth bug"  # AI-generated with instructions (equals sign required)
+but commit <branch> -m "message" --status-after  # Commit then show workspace status
+but commit <branch> -c -m "message"      # Create new branch (or use existing) and commit
+but commit <branch> -n -m "message"      # Bypass git commit hooks (pre-commit, commit-msg, post-commit)
+but commit empty --before <target>       # Insert empty commit before target
+but commit empty --after <target>        # Insert empty commit after target
+```
+
+**Important:** Without `--only`, ALL uncommitted changes are committed to the branch, not just staged files. Use `--only` when you've staged specific files and want to commit only those.
+
+**Committing specific files or hunks:** Use `--changes` (or `-p`) with comma-separated CLI IDs to commit only those files or hunks:
+- **File IDs** from `but status --json`: commits entire files
+- **Hunk IDs** from `but diff --json`: commits individual hunks
+- `--changes` takes one argument per flag. Use `--changes a1,b2` or `--changes a1 --changes b2`, not `--changes a1 b2`.
+
+**Note:** `--changes` and `--only` are mutually exclusive.
+
+**AI commit messages:** Use `-i` / `--ai` by itself for auto-generated messages, or `--ai="your instructions"` (equals sign required) to provide guidance.
+
+**Creating branches on commit:** Use `-c` / `--create` to create a new branch for the commit. If the branch name matches an existing branch, that branch is used instead.
+
+Example: `but commit my-branch -m "Fix bug" --changes ab,cd` commits files/hunks `ab` and `cd`.
+
+To commit specific hunks from a file with multiple changes, use `but diff --json` to see hunk IDs, then specify them individually.
+
+If only one branch is applied, you can omit the branch ID.
+
+### `but absorb [source]`
+
+Automatically amend uncommitted changes into existing commits.
+
+```bash
+but absorb <file-id>          # Absorb specific file (recommended)
+but absorb <branch-id>        # Absorb all changes staged to this branch
+but absorb                    # Absorb ALL uncommitted changes (use with caution)
+but absorb --dry-run          # Preview without making changes
+but absorb <file-id> --dry-run  # Preview specific file absorption
+but absorb --new/-n           # Create new commits instead of amending existing ones
+but absorb --status-after     # Absorb then show workspace status
+```
+
+**Recommendation:** Prefer targeted absorb (`but absorb <file-id>`) over absorbing everything. Running `but absorb` without arguments absorbs ALL uncommitted changes across all branches, which may not be what you want.
+
+Logic:
+
+- Changes amended into topmost commit of their branch
+- Changes depending on specific commit amended into that commit
+- Uses smart matching to find appropriate commits
+
+## Editing History
+
+### `but rub <source> <dest>`
+
+Universal editing primitive that does different operations based on types.
+
+```bash
+but rub <file> <branch>      # Stage file to branch
+but rub <file> <commit>      # Amend file into commit
+but rub <commit> <commit>    # Squash commits together
+but rub <commit> <branch>    # Move commit to branch
+but rub <file> zz            # Unstage file (back to unassigned)
+but rub <commit> zz          # Undo commit (uncommit to unstaged)
+but rub zz <branch>          # Stage all unassigned changes to branch
+but rub zz <commit>          # Amend all unassigned changes into commit
+but rub <file-in-commit> zz  # Uncommit specific file from its commit
+but rub <file-in-commit> <commit>  # Move file from one commit to another
+but rub <branch> <branch>    # Reassign all uncommitted changes between branches
+but rub <file> <commit> --status-after  # Amend then show workspace status
+```
+
+The core "rub two things together" operation.
+
+**Full operations matrix:**
+
+```
+SOURCE ↓ / TARGET →  │ zz (unassigned) │ Commit     │ Branch      │ Stack
+─────────────────────┼─────────────────┼────────────┼─────────────┼────────────
+File/Hunk            │ Unstage         │ Amend      │ Stage       │ Stage
+Commit               │ Undo            │ Squash     │ Move        │ -
+Branch (all changes) │ Unstage all     │ Amend all  │ Reassign    │ Reassign
+Stack (all changes)  │ Unstage all     │ -          │ Reassign    │ Reassign
+Unassigned (zz)      │ -               │ Amend all  │ Stage all   │ Stage all
+File-in-Commit       │ Uncommit        │ Move       │ Uncommit to │ -
+```
+
+`zz` is a special target meaning "unassigned" (no branch).
+
+### `but squash <commits>`
+
+Squash commits together.
+
+```bash
+but squash <c1> <c2> <c3>    # Squash multiple commits (into last)
+but squash <c1>..<c4>        # Squash a range
+but squash <branch>          # Squash all commits in branch into bottom-most
+but squash <branch> -d       # Squash and drop source commit messages (keep target's)
+but squash <branch> -m "msg" # Squash with a new commit message
+but squash <branch> -i       # Squash with AI-generated commit message
+but squash <branch> --status-after  # Squash then show workspace status
+```
+
+### `but amend <file> <commit>`
+
+Amend file into a specific commit. Use when you know exactly which commit the change belongs to.
+
+```bash
+but amend <file-id> <commit-id>                  # Amend file into specific commit
+but amend <file-id> <commit-id> --status-after   # Amend then show workspace status
+```
+
+**When to use `amend` vs `absorb`:**
+- `but amend` - You know the target commit; explicit control
+- `but absorb` - Let GitButler auto-detect the target; smart matching based on dependencies
+
+Alias for `but rub <file> <commit>`.
+
+### `but move <commit> <target>`
+
+Move a commit to a different location.
+
+```bash
+but move <source> <target>           # Move before target
+but move <source> <target> --after   # Move after target
+but move <commit> <branch>           # Move to top of branch
+but move <commit> <branch> --status-after  # Move then show workspace status
+```
+
+### `but uncommit <source>`
+
+Uncommit changes back to unstaged area.
+
+```bash
+but uncommit <commit-id>      # Uncommit entire commit
+but uncommit <file-id>        # Uncommit specific file from its commit
+but uncommit <commit-id> --status-after  # Uncommit then show workspace status
+```
+
+### `but reword <id>`
+
+Reword commit message or rename branch.
+
+```bash
+but reword <id>               # Interactive editor
+but reword <id> -m "new"      # Non-interactive
+but reword <id> --format      # Format to 72-char wrapping
+```
+
+### `but discard <id>`
+
+Discard uncommitted changes.
+
+```bash
+but discard <file-id>         # Discard file changes
+but discard <hunk-id>         # Discard hunk changes
+```
+
+## Conflict Resolution
+
+When commits have conflicts (shown in `but status`):
+
+### `but resolve <commit>`
+
+Enter resolution mode for a conflicted commit.
+
+```bash
+but resolve <commit-id>
+```
+
+### `but resolve status`
+
+Show remaining conflicted files.
+
+```bash
+but resolve status
+```
+
+### `but resolve finish`
+
+Finalize conflict resolution.
+
+```bash
+but resolve finish
+```
+
+### `but resolve cancel`
+
+Cancel conflict resolution and return to workspace mode.
+
+```bash
+but resolve cancel
+```
+
+**Workflow:**
+
+1. `but resolve <commit>` - Enter mode
+2. Edit files to resolve conflicts
+3. `but resolve status` - Check progress
+4. `but resolve finish` - Complete
+
+## Remote Operations
+
+### `but push [branch]`
+
+Push branches to remote.
+
+```bash
+but push                      # Push all branches with unpushed commits
+but push <branch-id>          # Push specific branch
+but push --dry-run            # Preview what would be pushed
+but push --with-force         # Force push (use carefully!)
+but push -s                   # Skip force push protection checks
+but push -r                   # Run pre-push hooks
+```
+
+### `but pull`
+
+Update all branches with target branch changes.
+
+```bash
+but pull                      # Fetch and rebase all branches
+but pull --check              # Check if can merge cleanly (no changes)
+```
+
+Run regularly to stay up to date with main development line.
+
+### `but pr`
+
+Create and manage pull requests.
+
+```bash
+but pr new <branch-id>        # Push branch and create PR (recommended)
+but pr new <branch-id> -F pr_message.txt    # Use file: first line is title, rest is description
+but pr new <branch-id> -m "Title..."        # Inline message: first line is title, rest is description
+but pr new <branch-id> -t     # Use default content (commit message), skip prompts
+but pr                        # Create PR (prompts for branch)
+but pr template               # Configure PR description template
+```
+
+**Key behavior:** `but pr new` automatically pushes the branch to remote before creating the PR. No need to run `but push` first. Force push (`--with-force`) and pre-push hooks (`--run-hooks`) are enabled by default.
+
+In non-interactive environments, use `--message (-m)`, `--file (-F)`, or `--default (-t)` to avoid editor prompts. The `-t` flag uses the commit message as title/description for single-commit branches; for multi-commit branches it falls back to the branch name as the title.
+
+**Note:** For stacked branches, the custom message (`-m` or `-F`) only applies to the selected branch. Dependent branches in the stack will use default messages (commit title/description).
+
+Requires forge integration to be configured via `but config forge auth`.
+
+### `but merge <branch>`
+
+Merge branch into local target branch.
+
+```bash
+but merge <branch-id>
+```
+
+Merges into local target branch, then runs `but pull` to update.
+
+## Automation
+
+### `but mark <target>`
+
+Auto-stage or auto-commit new changes.
+
+```bash
+but mark <branch-id>          # New unstaged changes auto-stage to this branch
+but mark <commit-id>          # New changes auto-amend into this commit
+but mark <id> --delete        # Remove the mark
+```
+
+### `but unmark`
+
+Remove all marks.
+
+```bash
+but unmark
+```
+
+Use marks when working on a focused area to automatically organize changes.
+
+## History & Undo
+
+### `but undo`
+
+Undo last operation.
+
+```bash
+but undo
+```
+
+Reverts to previous oplog snapshot.
+
+### `but oplog`
+
+View operation history.
+
+```bash
+but oplog
+but oplog --json
+```
+
+Shows all operations with snapshot IDs.
+
+### `but oplog restore <snapshot>`
+
+Restore to a specific oplog snapshot.
+
+```bash
+but oplog restore <snapshot-id>
+```
+
+## Setup & Configuration
+
+### `but setup`
+
+Initialize GitButler in current git repository.
+
+```bash
+but setup
+but setup --init              # Also initialize a new git repo if none exists
+```
+
+Converts regular git repo to use GitButler workspace model. Use `--init` in non-interactive environments (CI/CD) to ensure a git repository exists before setup.
+
+### `but teardown`
+
+Exit GitButler mode and return to normal git workflow.
+
+```bash
+but teardown
+```
+
+### `but config`
+
+View and manage GitButler configuration.
+
+```bash
+but config
+```
+
+### `but gui`
+
+Open GitButler GUI for current project.
+
+```bash
+but gui
+```
+
+### `but update`
+
+Manage GitButler CLI and app updates.
+
+```bash
+but update
+```
+
+### `but alias`
+
+Manage command aliases.
+
+```bash
+but alias
+```
+
+## Global Options
+
+Available on most commands:
+
+- `-j, --json` - Output in JSON format for parsing
+- `--status-after` - After a mutation command, also output workspace status. In human mode, prints status after the command output. In JSON mode, wraps both in `{"result": ..., "status": ...}` on success, or `{"result": ..., "status_error": "..."}` if the status query fails. Supported on: `rub`, `commit`, `stage`, `amend`, `absorb`, `squash`, `move`, `uncommit`.
+- `-C, --current-dir <PATH>` - Run as if started in different directory
+- `-h, --help` - Show help for command
+
+## Getting More Help
+
+```bash
+but --help                    # List all commands
+but <subcommand> --help       # Detailed help for specific command
+```
+
+Full documentation: <https://docs.gitbutler.com/cli-overview>

--- a/.factory/skills/gitbutler/SKILL.md
+++ b/.factory/skills/gitbutler/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: but
+version: 0.19.1
+description: "Commit, push, branch, and manage version control with GitButler. Use for: commit my changes, check what changed, create a PR, push my branch, view diff, create branches, stage files, edit commit history, squash commits, amend commits, undo commits, pull requests, merge, stash work. Replaces git - use 'but' instead of git commit, git status, git push, git checkout, git add, git diff, git branch, git rebase, git stash, git merge. Covers all git, version control, and source control operations."
+author: GitButler Team
+---
+
+# GitButler CLI Skill
+
+Use GitButler CLI (`but`) as the default version-control interface.
+
+## Non-Negotiable Rules
+
+1. Use `but` for all write operations. Never run `git add`, `git commit`, `git push`, `git checkout`, `git merge`, `git rebase`, `git stash`, or `git cherry-pick`.
+2. Start every write/history-edit task with `but status --json`.
+3. For mutation commands, always add `--json --status-after`.
+4. Use CLI IDs from `but status --json` / `but diff --json` / `but show --json`; do not hardcode IDs and do not switch branches with `git checkout`.
+5. After a successful mutation with `--status-after`, do not run a redundant `but status` unless needed for new IDs.
+6. If the user says a `git` write command (for example "git push"), translate it to the `but` equivalent and execute the `but` command directly.
+7. For branch-update tasks, run `but pull --check --json` before `but pull --json --status-after`. Do not substitute `but fetch` + status summaries for this check.
+8. Avoid routine `--help` probes before mutations. Use the command patterns in this skill (and `references/reference.md`) first; only use `--help` when syntax is genuinely unclear or after a failed attempt.
+
+## Core Flow
+
+```bash
+but status --json
+# If new branch needed:
+but branch new <name>
+# Perform task with IDs from status/diff/show
+but <mutation> ... --json --status-after
+```
+
+## Canonical Command Patterns
+
+- Commit specific files/hunks:
+  `but commit <branch> -m "<message>" --changes <id>,<id> --json --status-after`
+- Create branch while committing:
+  `but commit <branch> -c -m "<message>" --changes <id> --json --status-after`
+- Amend into a known commit:
+  `but amend <file-id> <commit-id> --json --status-after`
+- Reorder commits:
+  `but move <source-commit-id> <target-commit-id> --json --status-after`
+- Push:
+  `but push`
+  or
+  `but push <branch-id>`
+- Pull update safety flow:
+  `but pull --check --json`
+  then
+  `but pull --json --status-after`
+
+## Task Recipes
+
+### Commit one file
+
+1. `but status --json`
+2. Find that file's `cliId`
+3. `but commit <branch> -c -m "<clear message>" --changes <file-id> --json --status-after`
+
+### Commit only A, not B
+
+1. `but status --json`
+2. Find `src/a.rs` ID and `src/b.rs` ID
+3. Commit with `--changes <a-id>` only
+
+### User says "git push"
+
+Interpret as GitButler push. Run `but push` (or `but push <branch-id>`) immediately.
+Do not run `git push`, even if `but push` reports nothing to push.
+
+### Check mergeability, then update branches
+
+1. Run exactly: `but pull --check --json`
+2. If user asked to proceed, run: `but pull --json --status-after`
+3. Do not replace step 1 with `but fetch`, `but status`, or a narrative-only summary.
+
+### Amend into existing commit
+
+1. `but status --json`
+2. Locate file ID and commit ID from `status` (or `but show <branch-id> --json`)
+3. Run exactly: `but amend <file-id> <commit-id> --json --status-after`
+4. Never use `git checkout` or `git commit --amend`
+
+### Reorder commits
+
+1. `but status --json`
+2. Identify source/target commit IDs in the branch by commit message
+3. Run: `but move <commit-a> <commit-b> --json --status-after`
+4. From the returned `status`, refresh IDs and then run the inverse move:
+   `but move <commit-b> <commit-a> --json --status-after`
+5. This two-step sequence is the safe default for reorder requests.
+6. Never use `git rebase` for this.
+
+## Git-to-But Map
+
+- `git status` -> `but status --json`
+- `git add` + `git commit` -> `but commit ... --changes ... --json --status-after`
+- `git checkout -b` -> `but branch new <name>`
+- `git push` -> `but push`
+- `git rebase -i` -> `but move`, `but squash`, `but reword`
+- `git cherry-pick` -> `but pick`
+
+## Notes
+
+- Prefer explicit IDs over file paths for mutations.
+- `--changes` is the safe default for precise commits.
+- `--changes` accepts one argument per flag. For multiple IDs, use comma-separated values (`--changes a1,b2`) or repeat the flag (`--changes a1 --changes b2`), not `--changes a1 b2`.
+- Read-only git inspection is allowed (`git log`, `git blame`) when needed.
+- Keep skill version checks low-noise:
+  - Do not run `but skill check` as a routine preflight on every task.
+  - Run `but skill check` when command behavior appears to diverge from this skill (for example: unexpected unknown-flag errors, missing subcommands, or output shape mismatches), or when the user asks.
+  - If update is available, recommend `but skill check --update` (or run it if the user asked to update).
+- For deeper command syntax and flags, use `references/reference.md`.
+- For workspace model and dependency behavior, use `references/concepts.md`.
+- For end-to-end workflow patterns, use `references/examples.md`.

--- a/.factory/skills/gitbutler/references/concepts.md
+++ b/.factory/skills/gitbutler/references/concepts.md
@@ -1,0 +1,353 @@
+# GitButler CLI Key Concepts
+
+Deep dive into GitButler's conceptual model and philosophy.
+
+## The Workspace Model
+
+### Traditional Git: Serial Branching
+
+```
+main ──┬── feature-a (checkout here, work, commit, checkout back)
+       └── feature-b (checkout here, work, commit, checkout back)
+```
+
+- Work on ONE branch at a time
+- Switch contexts with `git checkout`
+- Changes are isolated by branch
+
+### GitButler: Parallel Stacks
+
+```
+workspace (gitbutler/workspace)
+  ├─ feature-a (applied, merged into workspace)
+  ├─ feature-b (applied, merged into workspace)
+  └─ feature-c (unapplied, not in workspace)
+```
+
+- Work on MULTIPLE branches simultaneously
+- No context switching - all applied branches merged in working directory
+- Changes are ASSIGNED to branches, not isolated by checkout
+
+### Key Implications
+
+1. **No `git checkout`**: You don't switch between branches. All applied branches exist simultaneously in your workspace.
+
+2. **Multiple staging areas**: Each branch is like having its own `git add` staging area. You stage files to specific branches.
+
+3. **The `gitbutler/workspace` branch**: A merge commit containing all applied stacks. Don't interact with it directly - use `but` commands.
+
+4. **Applied vs Unapplied**: Control which branches are active:
+   - Applied branches: In your working directory
+   - Unapplied branches: Exist but not active
+   - Use `but apply`/`but unapply` to control
+
+## CLI IDs: Short Identifiers
+
+Every object gets a short, human-readable CLI ID shown in `but status`. IDs are generated per-session and are unique across all entity types (no two objects share an ID) — always read them from `but status --json`.
+
+```
+Commits:    1b, 8f, c2     (short hex prefixes of the SHA, long enough to be unique)
+Branches:   fe, bu, ui     (unique 2–3 char substring of the branch name, e.g. "fe" from "feature-x";
+                             falls back to auto-generated ID if no unique substring exists)
+Files:      g0, h0, i0     (auto-generated, 2–3 chars)
+Hunks:      j0, k1, l2     (auto-generated, 2–3 chars)
+Stacks:     m0, n0          (auto-generated, 2–3 chars)
+```
+
+**Why?** Git commit SHAs are long (40 chars). CLI IDs are short (2-3 chars) and unique within your current workspace context.
+
+**Usage:** Pass these IDs as arguments to commands:
+
+```bash
+but commit <branch-id> -m "message"      # Commit to branch
+but stage <file-id> <branch-id>          # Stage file to branch
+but rub <commit-id> <commit-id>          # Squash commits
+```
+
+## Parallel vs Stacked Branches
+
+### Parallel Branches (Independent Work)
+
+Create with `but branch new <name>`:
+
+```
+main ──┬── api-endpoint (independent)
+       └── ui-update    (independent)
+```
+
+Use when:
+
+- Tasks don't depend on each other
+- Can be merged independently
+- No shared code between them
+
+Example: Adding a new API endpoint and updating button styles are independent.
+
+### Stacked Branches (Dependent Work)
+
+Create with `but branch new <name> -a <anchor>`:
+
+```
+main ── authentication ── user-profile ── settings-page
+        (base)            (stacked)       (stacked)
+```
+
+Use when:
+
+- Feature B needs code from Feature A
+- Building incrementally on previous work
+- Creating a series of related changes
+
+Example: User profile page needs authentication to be implemented first.
+
+**Dependency tracking:** GitButler automatically tracks which changes depend on which commits. You can't stage dependent changes to the wrong branch.
+
+## Multiple Staging Areas
+
+Traditional git has ONE staging area:
+
+```bash
+git add file1.js    # Stage to THE staging area
+git add file2.js    # Stage to THE staging area
+git commit          # Commit from THE staging area
+```
+
+GitButler has MULTIPLE staging areas (one per branch):
+
+```bash
+but stage file1.js api-branch    # Stage to api-branch's staging area
+but stage file2.js ui-branch     # Stage to ui-branch's staging area
+but commit api-branch -m "..."   # Commit from api-branch's staging area
+but commit ui-branch -m "..."    # Commit from ui-branch's staging area
+```
+
+**Unstaged changes:** Files not staged to any branch yet. Use `but status` to see them, then `but stage` to assign them.
+
+**Auto-assignment:** If only one branch is applied, changes may auto-assign to it.
+
+## The `but rub` Philosophy
+
+`but rub` is the core primitive operation: "rub two things together" to perform an action.
+
+### What Happens Based on Types
+
+The operation performed depends on what you combine:
+
+```
+SOURCE ↓ / TARGET →  │ zz (unassigned) │ Commit     │ Branch      │ Stack
+─────────────────────┼─────────────────┼────────────┼─────────────┼────────────
+File/Hunk            │ Unstage         │ Amend      │ Stage       │ Stage
+Commit               │ Undo            │ Squash     │ Move        │ -
+Branch (all changes) │ Unstage all     │ Amend all  │ Reassign    │ Reassign
+Stack (all changes)  │ Unstage all     │ -          │ Reassign    │ Reassign
+Unassigned (zz)      │ -               │ Amend all  │ Stage all   │ Stage all
+File-in-Commit       │ Uncommit        │ Move       │ Uncommit & assign │ -
+```
+
+`zz` is a special target meaning "unassigned" (no branch).
+
+**Common examples:**
+
+| Source | Target | Operation | Example |
+|--------|--------|-----------|---------|
+| File | Branch | Stage file to branch | `but rub a1 bu` |
+| File | Commit | Amend file into commit | `but rub a1 c3` |
+| Commit | Commit | Squash commits | `but rub c2 c3` |
+| Commit | Branch | Move commit to branch | `but rub c2 bu` |
+| File | `zz` | Unstage file | `but rub a1 zz` |
+| Commit | `zz` | Undo commit | `but rub c2 zz` |
+| `zz` | Branch | Stage all unassigned | `but rub zz bu` |
+
+### Higher-Level Conveniences
+
+These commands are wrappers around `but rub`:
+
+- `but stage <file> <branch>` = `but rub <file> <branch>`
+- `but amend <file> <commit>` = `but rub <file> <commit>`
+- `but squash` = Multiple `but rub <commit> <commit>` operations
+- `but move` = `but rub <commit> <target>` with position control
+
+**Why this design?** One powerful primitive is easier to understand and maintain than many specialized commands. Once you understand `but rub`, you understand the editing model.
+
+## Dependency Tracking
+
+GitButler tracks dependencies between changes automatically.
+
+### How It Works
+
+```
+Commit C1: Added function foo()
+Commit C2: Added function bar()
+Uncommitted: Call to foo() in new code
+```
+
+The uncommitted change **depends on** C1 (because it calls `foo()`).
+
+**Implications:**
+
+1. Can't stage this change to a branch that doesn't have C1
+2. `but absorb` will automatically amend it into C1 (or a commit after C1)
+3. If you try to move the change, GitButler prevents invalid operations
+
+### Why This Matters
+
+Prevents you from creating broken states:
+
+- Can't move dependent code away from its dependencies
+- Can't stage changes to wrong branches
+- Ensures each branch remains independently functional
+
+## Empty Commits as Placeholders
+
+You can create empty commits:
+
+```bash
+but commit empty --before c3
+but commit empty --after c3
+```
+
+**Use cases:**
+
+1. **Mark future work:** Create empty commit as placeholder for changes you'll make
+2. **Mark targets:** Use with `but mark <empty-commit-id>` so future changes auto-amend into it
+3. **Organize history:** Add semantic markers in commit history
+
+Example workflow:
+
+```bash
+but commit empty -m "TODO: Add error handling" --before c5
+but mark <empty-commit-id>
+# Now work on error handling, changes auto-amend into the placeholder
+```
+
+## Auto-Staging and Auto-Commit (Marks)
+
+Set a "mark" on a branch or commit to automatically organize new changes.
+
+### Mark a Branch
+
+```bash
+but mark <branch-id>
+```
+
+New unstaged changes automatically stage to this branch. Useful when focused on one feature.
+
+### Mark a Commit
+
+```bash
+but mark <commit-id>
+```
+
+New changes automatically amend into this commit. Useful for iterative refinement.
+
+### Remove Marks
+
+```bash
+but mark <id> --delete    # Remove specific mark
+but unmark                # Remove all marks
+```
+
+**Example workflow:**
+
+```bash
+but branch new refactor
+but mark <refactor-branch-id>
+# Make lots of changes - they all auto-stage to refactor branch
+but unmark
+```
+
+## Operation History (Oplog)
+
+Every operation in GitButler is recorded in the oplog (operation log).
+
+### What Gets Recorded
+
+- Branch creation/deletion
+- Commits
+- Stage operations
+- Rub/squash/move operations
+- Push/pull operations
+
+### Using Oplog
+
+```bash
+but oplog                      # View history
+but undo                       # Undo last operation
+but oplog restore <snapshot-id>  # Restore to specific point
+```
+
+Think of it as "git reflog" but for all GitButler operations, not just branch movements.
+
+**Safety net:** Made a mistake? `but undo` it. Experimented and want to go back? `but oplog restore` to earlier snapshot.
+
+## Applied vs Unapplied Branches
+
+Branches can be in two states:
+
+### Applied Branches
+
+- Active in your workspace
+- Merged into `gitbutler/workspace`
+- Changes visible in working directory
+- Can make changes, commit, stage files
+
+### Unapplied Branches
+
+- Exist but not active
+- Not in working directory
+- Can't make changes (must apply first)
+- Useful for temporarily setting aside work
+
+### Controlling State
+
+```bash
+but apply <id>             # Make branch active
+but unapply <id>           # Make branch inactive
+```
+
+**Use cases:**
+
+- Unapply branches causing conflicts
+- Focus on subset of work (unapply others)
+- Temporarily set aside work without deleting
+
+## Conflict Resolution Mode
+
+When `but pull` causes conflicts, affected commits are marked as conflicted.
+
+### Resolution Workflow
+
+1. **Identify:** `but status` shows conflicted commits
+2. **Enter mode:** `but resolve <commit-id>`
+3. **Fix conflicts:** Edit files, remove conflict markers
+4. **Check:** `but resolve status` shows remaining conflicts
+5. **Finalize:** `but resolve finish` or `but resolve cancel`
+
+### During Resolution
+
+- You're in a special mode focused on that commit
+- Other GitButler operations are limited
+- `but status` shows you're in resolution mode
+- Must finish or cancel before continuing normal work
+
+## Read-Only Git Commands
+
+Git commands that don't modify state are safe to use:
+
+**Safe (read-only):**
+
+- `git log` - View history
+- `git diff` - See changes (but prefer `but diff` — it supports CLI IDs and `--json`)
+- `git show` - View commits
+- `git blame` - See line history
+- `git reflog` - View reference log
+
+**Don't use in a GitButler workspace:**
+
+- `git status` - Misleading: shows merged workspace state, not individual stacks; missing CLI IDs that agents need
+- `git commit` - Commits to wrong place (bypasses branch assignment)
+- `git checkout` - Breaks workspace model
+- `git rebase` - Conflicts with GitButler's management
+- `git merge` - Use `but merge` instead
+
+**Rule of thumb:** If it reads, it's fine. If it writes, use `but` instead.

--- a/.factory/skills/gitbutler/references/examples.md
+++ b/.factory/skills/gitbutler/references/examples.md
@@ -1,0 +1,508 @@
+# GitButler CLI Workflow Examples
+
+Real-world examples of common workflows.
+
+**Note on CLI IDs:** Examples below use illustrative IDs like `bu`, `c3`, `a1` to keep commands readable. In practice, **always read actual IDs from `but status --json`** — they are generated per-session and will differ from these examples. Branch IDs are derived from unique substrings of the branch name (e.g., `fe` from `feature-x`), commit IDs use short hex prefixes (e.g., `1b`, `8f`), and file/hunk/stack IDs are auto-generated (e.g., `g0`, `h0`). All IDs are unique across entity types.
+
+## Example 1: Starting Independent Parallel Work
+
+**Scenario:** Need to work on two independent features: a new API endpoint and UI styling updates.
+
+```bash
+# 1. Check current state
+but status --json
+
+# 2. Create two independent (parallel) branches
+but branch new api-endpoint
+but branch new ui-styling
+
+# 3. Make changes to multiple files
+# (edit api/users.js and components/Button.svelte)
+
+# 4. Check what's unstaged
+but status --json
+
+# 5. Commit specific files directly using --changes (recommended for agents)
+# Use cliId values from but status --json output (e.g., branch IDs and file IDs)
+# For multiple IDs, use one comma-separated argument or repeat --changes.
+but commit <api-branch-id> -m "Add user details endpoint" --changes <api-file-id> --json --status-after
+but commit <ui-branch-id> -m "Update button hover styles" --changes <ui-file-id> --json --status-after
+
+# Alternative: stage first, then commit with --only
+# but stage <api-file-id> <api-branch-id> && but stage <ui-file-id> <ui-branch-id>
+# but commit <api-branch-id> --only -m "Add user details endpoint" --json --status-after
+# but commit <ui-branch-id> --only -m "Update button hover styles" --json --status-after
+
+# 6. Push branches independently (optional, can skip if using pr new)
+but push <api-branch-id> --json
+but push <ui-branch-id> --json
+
+# 7. Create pull requests (auto-pushes if not already pushed)
+but pr new <api-branch-id> --json
+but pr new <ui-branch-id> --json
+```
+
+**Why parallel branches?** The API endpoint and UI styling are independent - neither depends on the other. They can be reviewed and merged separately.
+
+## Example 2: Building Stacked Features
+
+**Scenario:** Need to add authentication, then build a user profile page that requires auth.
+
+```bash
+# 1. Check current state and update
+but pull --json
+but status --json
+
+# 2. Create base branch for authentication
+but branch new add-authentication
+
+# 3. Implement auth and commit
+# (edit auth/login.js, auth/middleware.js)
+but status --json
+but stage <file-ids> bu --json --status-after  # Stage changes to auth branch
+but commit bu --only -m "Add JWT authentication" --json --status-after
+
+# 4. Create stacked branch anchored on authentication
+but branch new user-profile -a bu
+
+# 5. Implement profile page (depends on auth)
+# (edit pages/profile.js)
+but status --json
+but stage <file-ids> bv --json --status-after  # Stage changes to profile branch
+but commit bv --only -m "Add user profile page" --json --status-after
+
+# 6. Push both branches (maintains stack relationship)
+but push --json
+```
+
+**Result:** Two PRs where user-profile PR depends on authentication PR. GitHub/GitLab shows the dependency.
+
+## Example 3: Using Absorb Instead of New Commits
+
+**Scenario:** Made a small typo fix that should be part of the last commit, not a new commit.
+
+```bash
+# 1. Check current commits and unstaged changes
+but status --json
+
+# Output shows:
+# Branch: feature-x (bu)
+# Commits:
+#   c3: Implement feature logic
+#   c2: Add feature tests
+# Unstaged:
+#   a1: fix-typo.js (staged to bu)
+
+# 2. Preview what absorb would do (recommended first step)
+but absorb a1 --dry-run --json    # Shows where a1 would be absorbed
+
+# 3. Absorb the specific file into appropriate commit
+but absorb a1 --json --status-after    # Absorb just this file + get updated status
+
+# GitButler analyzes the change and amends it into c3
+# (because the typo is in code from c3)
+```
+
+**Targeted vs blanket absorb:**
+
+```bash
+but absorb a1 --json --status-after    # Absorb specific file (recommended)
+but absorb bu --json --status-after    # Absorb all changes staged to branch bu
+but absorb --json --status-after       # Absorb ALL uncommitted changes (use with caution)
+```
+
+**Why absorb?** Keeps history clean. Small fixes belong in the commits they fix, not as separate "fix typo" commits.
+
+## Example 4: Reorganizing Commit History
+
+### Scenario A: Squashing Commits
+
+**Situation:** Made 5 small WIP commits, want to combine into one logical commit.
+
+```bash
+# Before:
+# c5: More tweaks
+# c4: Fix another thing
+# c3: Fix tests
+# c2: Adjust logic
+# c1: Initial implementation
+
+# Squash all commits in branch
+but squash bu --json --status-after
+
+# Or squash specific range
+but squash c2..c5 --json --status-after    # Squashes c2, c3, c4, c5 into one
+
+# Or squash specific commits
+but squash c2 c3 c4 --json --status-after    # Squashes these three
+```
+
+### Scenario B: Moving Files Between Commits
+
+**Situation:** A file was committed in the wrong commit, need to move it.
+
+```bash
+# 1. See which files are in which commits
+but status --json -f
+
+# Output shows:
+# c3: api.js, utils.js
+# c2: config.js
+
+# 2. Move utils.js from c3 to c2
+but rub a2 c2 --json --status-after    # File a2 (utils.js) → commit c2 + get updated status
+```
+
+### Scenario C: Moving Commit to Different Branch
+
+**Situation:** Committed to wrong branch, need to move commit.
+
+```bash
+# 1. Check current state
+but status --json
+
+# Output:
+# Branch: feature-a (bu)
+#   c3: This should be in feature-b!
+#   c2: Correct commit
+
+# 2. Create or identify target branch
+but branch new feature-b    # Creates branch bv
+
+# 3. Move the commit
+but move c3 bv --json --status-after    # Move c3 to top of branch bv
+```
+
+## Example 5: Using Marks for Focused Work
+
+**Scenario:** Working on a large refactor, want all changes to automatically stage to that branch.
+
+```bash
+# 1. Create refactor branch
+but branch new refactor
+
+# 2. Mark it for auto-staging
+but mark bu    # Branch bu (refactor) is now marked
+
+# 3. Make changes across many files
+# (edit 20 different files)
+
+# 4. All changes automatically staged to refactor branch
+but status --json  # Shows all changes staged to bu
+
+# 5. Commit the staged changes
+but commit bu --only -m "Refactor error handling across app" --json --status-after
+
+# 6. Remove mark
+but unmark
+```
+
+**Alternative: Mark a commit for auto-amend**
+
+```bash
+# 1. Create empty commit as placeholder
+but commit empty -m "TODO: Add error handling"
+
+# 2. Mark it
+but mark c5    # Commit c5 is now marked
+
+# 3. Make changes - they auto-amend into c5
+# (edit files)
+
+# 4. Check result
+but show c5 --json    # Shows accumulated changes
+
+# 5. Remove mark when done
+but unmark
+```
+
+## Example 6: Conflict Resolution
+
+**Scenario:** After `but pull`, conflicts appear in a commit.
+
+```bash
+# 1. Pull updates
+but pull --json
+
+# Output:
+# Conflict in commit c3 on branch feature-x
+
+# 2. Check status
+but status --json
+
+# Output:
+# Branch: feature-x (bu)
+#   c3: Add validation (CONFLICTED)
+
+# 3. Enter resolution mode
+but resolve c3
+
+# Output:
+# Entering resolution mode for commit c3
+# Fix conflicts in: api/users.js, api/validation.js
+
+# 4. Edit files to resolve conflicts
+# (open files, remove <<< === >>> markers)
+
+# 5. Check progress
+but resolve status
+
+# Output:
+# Remaining conflicts:
+#   api/validation.js
+
+# 6. Continue fixing...
+# (resolve last conflict)
+
+# 7. Finalize
+but resolve finish
+
+# Back to normal workspace mode
+```
+
+## Example 7: Complete Feature Development Workflow
+
+**Scenario:** Building a complete feature from start to finish.
+
+```bash
+# 1. Update to latest
+but pull --json
+
+# 2. Create branch for feature
+but branch new user-dashboard
+
+# 3. Make initial changes
+# (create dashboard.js, add routes)
+
+# 4. Check and stage
+but status --json
+but stage <file-ids> bu --json --status-after  # Stage changes to dashboard branch
+
+# 5. First commit
+but commit bu --only -m "Add dashboard route and basic layout" --json --status-after
+
+# 6. Continue iterating
+# (add widgets, styling)
+but stage <file-ids> bu --json --status-after
+but commit bu --only -m "Add dashboard widgets" --json --status-after
+but stage <file-ids> bu --json --status-after
+but commit bu --only -m "Style dashboard components" --json --status-after
+
+# 7. Make small fix
+# (fix typo in widget)
+but absorb a1 --json --status-after    # Absorb specific file into appropriate commit
+
+# 8. Clean up if needed
+but squash bu --json --status-after    # Combine all commits (optional)
+
+# 9. Push to remote (can also skip - pr new auto-pushes)
+but push bu --json
+
+# 10. Create pull request
+but pr new bu --json
+
+# Output:
+# Created PR #123: https://github.com/org/repo/pull/123
+
+# 11. After PR is merged, update
+but pull --json
+```
+
+## Example 8: Working with Applied/Unapplied Branches
+
+**Scenario:** Have 3 branches, but two are causing conflicts. Temporarily unapply them.
+
+```bash
+# 1. Check active branches
+but status --json
+
+# Output:
+# Applied branches:
+#   bu: feature-a
+#   bv: feature-b
+#   bw: feature-c
+
+# 2. Conflicts between feature-b and feature-c
+# Unapply them temporarily
+but unapply bv
+but unapply bw
+
+# 3. Focus on feature-a
+# (make changes, stage, commit)
+but stage <file-ids> bu --json --status-after
+but commit bu --only -m "Complete feature-a" --json --status-after
+
+# 4. Create PR for feature-a (auto-pushes)
+but pr new bu --json
+
+# 5. Reapply other branches
+but apply bv
+but apply bw
+
+# 6. Deal with their conflicts now
+but resolve ...
+```
+
+## Example 9: Fixing History Before Pushing
+
+**Scenario:** Made several commits, realized you need to reword messages and reorder.
+
+```bash
+# 1. Current state
+but status --json
+
+# Output:
+# Branch: feature-x (bu)
+#   c5: final commit
+#   c4: WIP
+#   c3: Fix stuff
+#   c2: Another fix
+#   c1: Initial
+
+# 2. Reword commit messages
+but reword c4 -m "Add validation logic"
+but reword c3 -m "Fix edge case in parser"
+but reword c2 -m "Update error messages"
+
+# 3. Move c5 to be earlier
+but move c5 c3 --json --status-after    # Move c5 before c3
+
+# 4. Squash similar commits
+but squash c2 c3 --json --status-after    # Combine error handling commits
+
+# Output:
+# Branch: feature-x (bu)
+#   c4: Add validation logic
+#   c3: final commit
+#   c2: Fix edge case in parser and update error messages
+#   c1: Initial
+
+# 5. Push clean history
+but push bu --json
+```
+
+## Example 10: Daily Development Workflow
+
+**Typical day working with GitButler:**
+
+```bash
+# Morning: Start day
+but pull --json                   # Get latest from team
+
+# Start new task
+but branch new fix-auth-bug       # Create branch for today's work
+
+# Work and commit iteratively
+# (make changes)
+but status --json                 # Check changes
+but stage <file-ids> bu --json --status-after    # Stage to branch
+but commit bu --only -m "Identify auth bug source" --json --status-after
+# (make more changes)
+but stage <file-ids> bu --json --status-after    # Stage to branch
+but commit bu --only -m "Fix token expiration handling" --json --status-after
+# (small fix to existing code)
+but absorb a1 --json --status-after              # Absorb specific fix into appropriate commit
+
+# Mid-day: Start urgent fix on different branch
+but branch new hotfix-login       # Parallel branch for urgent work
+# (make fix)
+but stage <file-ids> bv --json --status-after    # Stage to hotfix branch
+but commit bv --only -m "Fix login redirect loop" --json --status-after
+but pr new bv --json              # Push and create PR immediately
+
+# Back to original work
+# (continue working on bu, auth bug fix)
+but stage <file-ids> bu --json --status-after    # Stage to auth branch
+but commit bu --only -m "Add tests for token handling" --json --status-after
+
+# End of day: Clean up and create PR
+but squash bu --json --status-after    # Combine into clean history
+but pr new bu --json              # Push and create PR
+
+# After PR review: Make requested changes
+# (make changes based on feedback)
+but absorb <file-id> --json --status-after    # Absorb specific changes into commits
+# Or absorb all changes for this branch:
+but absorb bu --json --status-after          # Absorb all changes staged to bu
+but push bu --with-force --json   # Force push updated history
+```
+
+## Example 11: Recovering from Mistakes
+
+**Scenario:** Made changes you didn't mean to, need to undo.
+
+### Undo Last Operation
+
+```bash
+# Made a mistake
+but squash bu    # Oops! Didn't mean to squash
+
+# Undo it
+but undo         # Reverts the squash
+```
+
+### Restore to Earlier Point
+
+```bash
+# View operation history
+but oplog --json
+
+# Output:
+# s5: squash branch bu
+# s4: commit bu "message"
+# s3: stage files to bu
+# s2: create branch bu
+# s1: pull from remote
+
+# Restore to before squash
+but oplog restore s4
+```
+
+### Discard Uncommitted Changes
+
+```bash
+# Changed a file but want to discard
+but status --json
+
+# Output:
+# Unstaged:
+#   a1: bad-changes.js
+
+# Discard it
+but discard a1
+```
+
+## Tips and Tricks
+
+### Quick Status Check
+
+```bash
+but status --json -f    # File-centric view for quick overview
+```
+
+### Preview Before Doing
+
+```bash
+but absorb <file-id> --dry-run --json  # See where specific file would be absorbed
+but push --dry-run --json              # See what would be pushed
+```
+
+### JSON for Scripting
+
+```bash
+but status --json | jq '.branches[] | .name'    # List branch names
+```
+
+### Auto-completion
+
+```bash
+eval "$(but completions zsh)"     # Add to ~/.zshrc
+eval "$(but completions bash)"    # Add to ~/.bashrc
+```
+
+### Viewing History
+
+```bash
+but show bu --json       # Show all commits in branch
+git log bu               # Traditional git log (read-only, still works)
+```

--- a/.factory/skills/gitbutler/references/reference.md
+++ b/.factory/skills/gitbutler/references/reference.md
@@ -1,0 +1,566 @@
+# GitButler CLI Command Reference
+
+Comprehensive reference for all `but` commands.
+
+## Contents
+
+- [Inspection](#inspection-understanding-state) - `status`, `show`, `diff`
+- [Branching](#branching) - `branch new`, `apply`, `unapply`, `branch delete`, `pick`
+- [Staging](#staging-multiple-staging-areas) - `stage`, `rub`
+- [Committing](#committing) - `commit`, `absorb`
+- [Editing History](#editing-history) - `rub`, `squash`, `amend`, `move`, `uncommit`, `reword`, `discard`
+- [Conflict Resolution](#conflict-resolution) - `resolve`
+- [Remote Operations](#remote-operations) - `push`, `pull`, `pr`, `merge`
+- [Automation](#automation) - `mark`, `unmark`
+- [History & Undo](#history--undo) - `undo`, `oplog`
+- [Setup & Configuration](#setup--configuration) - `setup`, `teardown`, `config`, `gui`, `update`, `alias`
+- [Global Options](#global-options)
+
+## Inspection (Understanding State)
+
+### `but status`
+
+Overview of workspace state - this is your entry point.
+
+```bash
+but status              # Human-readable view
+but status -f           # File-centric view (shows which files in which commits)
+but status --json       # Structured output for parsing
+but status --verbose    # Detailed information
+but status --upstream   # Show upstream relationship
+```
+
+Shows:
+
+- Applied/unapplied branches in workspace
+- Uncommitted changes (unstaged files)
+- Commits on each stack
+- CLI IDs to use in other commands
+
+### `but show <id>`
+
+Details about a commit or branch.
+
+```bash
+but show <id>           # Show details
+but show <id> --verbose # More detailed information
+but show <id> --json    # Structured output
+```
+
+### `but diff [target]`
+
+Display diff for file, branch, stack, or commit.
+
+```bash
+but diff <file-id>      # Diff for specific file
+but diff <branch-id>    # Diff for all changes in branch
+but diff <commit-id>    # Diff for specific commit
+but diff                # Diff for entire workspace
+but diff --json         # JSON output with hunk IDs for `but commit --changes`
+```
+
+**Hunk IDs in JSON output:** For uncommitted changes, `but diff --json` returns each hunk as a separate entry in `changes[]` with an `id` field (e.g., `e8`, `j0`). Pass these IDs to `but commit --changes` for fine-grained, hunk-level commits. For commit/branch diffs, `id` is absent — entries are per-file with hunks nested under `diff.hunks`.
+
+## Branching
+
+### `but branch`
+
+List all branches (default when no subcommand).
+
+```bash
+but branch              # List branches
+but branch --json       # JSON output
+but branch list [filter]  # Filter branches by name (case-insensitive substring)
+but branch list --no-ahead  # Skip commits-ahead calculation (faster)
+but branch list --no-check  # Skip clean-merge check (faster)
+but branch list -r      # Show only remote branches
+but branch list -l      # Show only local branches
+but branch list -a      # Show all branches (not just active + 20 most recent)
+but branch list --review  # Fetch and display PR/MR information
+```
+
+### `but branch new <name>`
+
+Create a new branch.
+
+```bash
+but branch new feature              # Independent branch (parallel work)
+but branch new feature -a <anchor>  # Stacked branch (dependent work)
+```
+
+Use parallel branches for independent tasks. Use stacked branches when work depends on another branch.
+
+### `but apply <id>`
+
+Activate a branch in the workspace.
+
+```bash
+but apply <id>           # Activate branch in workspace
+```
+
+Applied branches are merged into `gitbutler/workspace` and visible in working directory.
+
+### `but unapply <id>`
+
+Deactivate a branch from the workspace.
+
+```bash
+but unapply <id>         # Deactivate branch from workspace
+```
+
+The identifier can be a CLI ID pointing to a stack or branch, or a branch name. If a branch is specified, the entire stack containing that branch will be unapplied.
+
+### `but branch delete <id>`
+
+Delete a branch.
+
+```bash
+but branch delete <id>
+but branch -d <id>      # Short form
+```
+
+### `but branch show <id>`
+
+Show commits ahead of base for a branch.
+
+```bash
+but branch show <id>
+but branch show <id> -f       # Show files modified in each commit with line counts
+but branch show <id> --ai     # Generate AI summary of branch changes
+but branch show <id> --check  # Check if branch merges cleanly into upstream
+but branch show <id> -r       # Fetch and display review information (PRs/MRs)
+```
+
+### `but pick <source> [target]`
+
+Cherry-pick commits from unapplied branches into applied branches.
+
+```bash
+but pick <commit-sha> <branch>       # Pick specific commit into branch
+but pick <cli-id> <branch>           # Pick using CLI ID (e.g., "c5")
+but pick <unapplied-branch>          # Interactive commit selection from branch
+but pick <commit-sha>                # Auto-select target if only one branch
+```
+
+The source can be:
+- A commit SHA (full or short)
+- A CLI ID from `but status`
+- An unapplied branch name (shows interactive commit picker)
+
+If no target is specified and multiple branches exist, prompts for selection interactively.
+
+## Staging (Multiple Staging Areas)
+
+GitButler has multiple staging areas - one per stack.
+
+### `but stage <file> <branch>`
+
+Stage file to a specific branch.
+
+```bash
+but stage <file-id> <branch-id>
+but stage <file-id> <branch-id> --status-after  # Stage then show workspace status
+```
+
+Alias for `but rub <file> <branch>`. You can't stage changes that depend on branch A to branch B.
+
+### `but rub <file> <branch>`
+
+Core primitive for staging (see Editing History for other `but rub` uses).
+
+```bash
+but rub <file-id> <branch-id>    # Stage file to branch
+```
+
+## Committing
+
+### `but commit [branch]`
+
+Commit changes to a branch.
+
+```bash
+but commit <branch> --only -m "message"  # Commit ONLY staged changes (recommended)
+but commit <branch> -m "message"         # Commit ALL uncommitted changes to branch
+but commit <branch> -m "message" --changes <id>,<id>  # Commit specific files or hunks by CLI ID
+but commit <branch> -m "message" --changes <id> --changes <id>  # Alternative: repeat flag
+but commit <branch> --message-file msg.txt  # Read commit message from file
+but commit <branch> -i                   # AI-generated commit message
+but commit <branch> -i="fix the auth bug"  # AI-generated with instructions (equals sign required)
+but commit <branch> -m "message" --status-after  # Commit then show workspace status
+but commit <branch> -c -m "message"      # Create new branch (or use existing) and commit
+but commit <branch> -n -m "message"      # Bypass git commit hooks (pre-commit, commit-msg, post-commit)
+but commit empty --before <target>       # Insert empty commit before target
+but commit empty --after <target>        # Insert empty commit after target
+```
+
+**Important:** Without `--only`, ALL uncommitted changes are committed to the branch, not just staged files. Use `--only` when you've staged specific files and want to commit only those.
+
+**Committing specific files or hunks:** Use `--changes` (or `-p`) with comma-separated CLI IDs to commit only those files or hunks:
+- **File IDs** from `but status --json`: commits entire files
+- **Hunk IDs** from `but diff --json`: commits individual hunks
+- `--changes` takes one argument per flag. Use `--changes a1,b2` or `--changes a1 --changes b2`, not `--changes a1 b2`.
+
+**Note:** `--changes` and `--only` are mutually exclusive.
+
+**AI commit messages:** Use `-i` / `--ai` by itself for auto-generated messages, or `--ai="your instructions"` (equals sign required) to provide guidance.
+
+**Creating branches on commit:** Use `-c` / `--create` to create a new branch for the commit. If the branch name matches an existing branch, that branch is used instead.
+
+Example: `but commit my-branch -m "Fix bug" --changes ab,cd` commits files/hunks `ab` and `cd`.
+
+To commit specific hunks from a file with multiple changes, use `but diff --json` to see hunk IDs, then specify them individually.
+
+If only one branch is applied, you can omit the branch ID.
+
+### `but absorb [source]`
+
+Automatically amend uncommitted changes into existing commits.
+
+```bash
+but absorb <file-id>          # Absorb specific file (recommended)
+but absorb <branch-id>        # Absorb all changes staged to this branch
+but absorb                    # Absorb ALL uncommitted changes (use with caution)
+but absorb --dry-run          # Preview without making changes
+but absorb <file-id> --dry-run  # Preview specific file absorption
+but absorb --new/-n           # Create new commits instead of amending existing ones
+but absorb --status-after     # Absorb then show workspace status
+```
+
+**Recommendation:** Prefer targeted absorb (`but absorb <file-id>`) over absorbing everything. Running `but absorb` without arguments absorbs ALL uncommitted changes across all branches, which may not be what you want.
+
+Logic:
+
+- Changes amended into topmost commit of their branch
+- Changes depending on specific commit amended into that commit
+- Uses smart matching to find appropriate commits
+
+## Editing History
+
+### `but rub <source> <dest>`
+
+Universal editing primitive that does different operations based on types.
+
+```bash
+but rub <file> <branch>      # Stage file to branch
+but rub <file> <commit>      # Amend file into commit
+but rub <commit> <commit>    # Squash commits together
+but rub <commit> <branch>    # Move commit to branch
+but rub <file> zz            # Unstage file (back to unassigned)
+but rub <commit> zz          # Undo commit (uncommit to unstaged)
+but rub zz <branch>          # Stage all unassigned changes to branch
+but rub zz <commit>          # Amend all unassigned changes into commit
+but rub <file-in-commit> zz  # Uncommit specific file from its commit
+but rub <file-in-commit> <commit>  # Move file from one commit to another
+but rub <branch> <branch>    # Reassign all uncommitted changes between branches
+but rub <file> <commit> --status-after  # Amend then show workspace status
+```
+
+The core "rub two things together" operation.
+
+**Full operations matrix:**
+
+```
+SOURCE ↓ / TARGET →  │ zz (unassigned) │ Commit     │ Branch      │ Stack
+─────────────────────┼─────────────────┼────────────┼─────────────┼────────────
+File/Hunk            │ Unstage         │ Amend      │ Stage       │ Stage
+Commit               │ Undo            │ Squash     │ Move        │ -
+Branch (all changes) │ Unstage all     │ Amend all  │ Reassign    │ Reassign
+Stack (all changes)  │ Unstage all     │ -          │ Reassign    │ Reassign
+Unassigned (zz)      │ -               │ Amend all  │ Stage all   │ Stage all
+File-in-Commit       │ Uncommit        │ Move       │ Uncommit to │ -
+```
+
+`zz` is a special target meaning "unassigned" (no branch).
+
+### `but squash <commits>`
+
+Squash commits together.
+
+```bash
+but squash <c1> <c2> <c3>    # Squash multiple commits (into last)
+but squash <c1>..<c4>        # Squash a range
+but squash <branch>          # Squash all commits in branch into bottom-most
+but squash <branch> -d       # Squash and drop source commit messages (keep target's)
+but squash <branch> -m "msg" # Squash with a new commit message
+but squash <branch> -i       # Squash with AI-generated commit message
+but squash <branch> --status-after  # Squash then show workspace status
+```
+
+### `but amend <file> <commit>`
+
+Amend file into a specific commit. Use when you know exactly which commit the change belongs to.
+
+```bash
+but amend <file-id> <commit-id>                  # Amend file into specific commit
+but amend <file-id> <commit-id> --status-after   # Amend then show workspace status
+```
+
+**When to use `amend` vs `absorb`:**
+- `but amend` - You know the target commit; explicit control
+- `but absorb` - Let GitButler auto-detect the target; smart matching based on dependencies
+
+Alias for `but rub <file> <commit>`.
+
+### `but move <commit> <target>`
+
+Move a commit to a different location.
+
+```bash
+but move <source> <target>           # Move before target
+but move <source> <target> --after   # Move after target
+but move <commit> <branch>           # Move to top of branch
+but move <commit> <branch> --status-after  # Move then show workspace status
+```
+
+### `but uncommit <source>`
+
+Uncommit changes back to unstaged area.
+
+```bash
+but uncommit <commit-id>      # Uncommit entire commit
+but uncommit <file-id>        # Uncommit specific file from its commit
+but uncommit <commit-id> --status-after  # Uncommit then show workspace status
+```
+
+### `but reword <id>`
+
+Reword commit message or rename branch.
+
+```bash
+but reword <id>               # Interactive editor
+but reword <id> -m "new"      # Non-interactive
+but reword <id> --format      # Format to 72-char wrapping
+```
+
+### `but discard <id>`
+
+Discard uncommitted changes.
+
+```bash
+but discard <file-id>         # Discard file changes
+but discard <hunk-id>         # Discard hunk changes
+```
+
+## Conflict Resolution
+
+When commits have conflicts (shown in `but status`):
+
+### `but resolve <commit>`
+
+Enter resolution mode for a conflicted commit.
+
+```bash
+but resolve <commit-id>
+```
+
+### `but resolve status`
+
+Show remaining conflicted files.
+
+```bash
+but resolve status
+```
+
+### `but resolve finish`
+
+Finalize conflict resolution.
+
+```bash
+but resolve finish
+```
+
+### `but resolve cancel`
+
+Cancel conflict resolution and return to workspace mode.
+
+```bash
+but resolve cancel
+```
+
+**Workflow:**
+
+1. `but resolve <commit>` - Enter mode
+2. Edit files to resolve conflicts
+3. `but resolve status` - Check progress
+4. `but resolve finish` - Complete
+
+## Remote Operations
+
+### `but push [branch]`
+
+Push branches to remote.
+
+```bash
+but push                      # Push all branches with unpushed commits
+but push <branch-id>          # Push specific branch
+but push --dry-run            # Preview what would be pushed
+but push --with-force         # Force push (use carefully!)
+but push -s                   # Skip force push protection checks
+but push -r                   # Run pre-push hooks
+```
+
+### `but pull`
+
+Update all branches with target branch changes.
+
+```bash
+but pull                      # Fetch and rebase all branches
+but pull --check              # Check if can merge cleanly (no changes)
+```
+
+Run regularly to stay up to date with main development line.
+
+### `but pr`
+
+Create and manage pull requests.
+
+```bash
+but pr new <branch-id>        # Push branch and create PR (recommended)
+but pr new <branch-id> -F pr_message.txt    # Use file: first line is title, rest is description
+but pr new <branch-id> -m "Title..."        # Inline message: first line is title, rest is description
+but pr new <branch-id> -t     # Use default content (commit message), skip prompts
+but pr                        # Create PR (prompts for branch)
+but pr template               # Configure PR description template
+```
+
+**Key behavior:** `but pr new` automatically pushes the branch to remote before creating the PR. No need to run `but push` first. Force push (`--with-force`) and pre-push hooks (`--run-hooks`) are enabled by default.
+
+In non-interactive environments, use `--message (-m)`, `--file (-F)`, or `--default (-t)` to avoid editor prompts. The `-t` flag uses the commit message as title/description for single-commit branches; for multi-commit branches it falls back to the branch name as the title.
+
+**Note:** For stacked branches, the custom message (`-m` or `-F`) only applies to the selected branch. Dependent branches in the stack will use default messages (commit title/description).
+
+Requires forge integration to be configured via `but config forge auth`.
+
+### `but merge <branch>`
+
+Merge branch into local target branch.
+
+```bash
+but merge <branch-id>
+```
+
+Merges into local target branch, then runs `but pull` to update.
+
+## Automation
+
+### `but mark <target>`
+
+Auto-stage or auto-commit new changes.
+
+```bash
+but mark <branch-id>          # New unstaged changes auto-stage to this branch
+but mark <commit-id>          # New changes auto-amend into this commit
+but mark <id> --delete        # Remove the mark
+```
+
+### `but unmark`
+
+Remove all marks.
+
+```bash
+but unmark
+```
+
+Use marks when working on a focused area to automatically organize changes.
+
+## History & Undo
+
+### `but undo`
+
+Undo last operation.
+
+```bash
+but undo
+```
+
+Reverts to previous oplog snapshot.
+
+### `but oplog`
+
+View operation history.
+
+```bash
+but oplog
+but oplog --json
+```
+
+Shows all operations with snapshot IDs.
+
+### `but oplog restore <snapshot>`
+
+Restore to a specific oplog snapshot.
+
+```bash
+but oplog restore <snapshot-id>
+```
+
+## Setup & Configuration
+
+### `but setup`
+
+Initialize GitButler in current git repository.
+
+```bash
+but setup
+but setup --init              # Also initialize a new git repo if none exists
+```
+
+Converts regular git repo to use GitButler workspace model. Use `--init` in non-interactive environments (CI/CD) to ensure a git repository exists before setup.
+
+### `but teardown`
+
+Exit GitButler mode and return to normal git workflow.
+
+```bash
+but teardown
+```
+
+### `but config`
+
+View and manage GitButler configuration.
+
+```bash
+but config
+```
+
+### `but gui`
+
+Open GitButler GUI for current project.
+
+```bash
+but gui
+```
+
+### `but update`
+
+Manage GitButler CLI and app updates.
+
+```bash
+but update
+```
+
+### `but alias`
+
+Manage command aliases.
+
+```bash
+but alias
+```
+
+## Global Options
+
+Available on most commands:
+
+- `-j, --json` - Output in JSON format for parsing
+- `--status-after` - After a mutation command, also output workspace status. In human mode, prints status after the command output. In JSON mode, wraps both in `{"result": ..., "status": ...}` on success, or `{"result": ..., "status_error": "..."}` if the status query fails. Supported on: `rub`, `commit`, `stage`, `amend`, `absorb`, `squash`, `move`, `uncommit`.
+- `-C, --current-dir <PATH>` - Run as if started in different directory
+- `-h, --help` - Show help for command
+
+## Getting More Help
+
+```bash
+but --help                    # List all commands
+but <subcommand> --help       # Detailed help for specific command
+```
+
+Full documentation: <https://docs.gitbutler.com/cli-overview>

--- a/internal/cache/multitier.go
+++ b/internal/cache/multitier.go
@@ -1,0 +1,161 @@
+// internal/cache/multitier.go
+package cache
+
+import (
+	"context"
+	"log"
+)
+
+// MultiTierConfig configures the multi-tier cache behavior
+type MultiTierConfig struct {
+	// WriteToRemote controls whether to write cache entries to the remote server
+	WriteToRemote bool
+
+	// ReadFromRemote controls whether to read from the remote server on local miss
+	ReadFromRemote bool
+
+	// PreferLocal controls whether to check local cache first (true) or remote first (false)
+	PreferLocal bool
+
+	// WarmLocalOnRemoteHit controls whether to populate local cache on remote hit
+	WarmLocalOnRemoteHit bool
+}
+
+// DefaultMultiTierConfig returns the default multi-tier cache configuration
+func DefaultMultiTierConfig() MultiTierConfig {
+	return MultiTierConfig{
+		WriteToRemote:        true,
+		ReadFromRemote:       true,
+		PreferLocal:          true,
+		WarmLocalOnRemoteHit: true,
+	}
+}
+
+// MultiTierCache implements CacheManager with local and optional remote tiers
+type MultiTierCache struct {
+	local  CacheManager
+	remote CacheManager // may be nil
+	config MultiTierConfig
+}
+
+// NewMultiTierCache creates a new multi-tier cache
+// If remote is nil, the cache operates in local-only mode
+func NewMultiTierCache(local CacheManager, remote CacheManager, config MultiTierConfig) *MultiTierCache {
+	return &MultiTierCache{
+		local:  local,
+		remote: remote,
+		config: config,
+	}
+}
+
+// Get retrieves a cache entry, checking local and remote tiers based on config
+func (c *MultiTierCache) Get(ctx context.Context, key CacheKey) (*CacheEntry, error) {
+	if c.config.PreferLocal {
+		return c.getLocalFirst(ctx, key)
+	}
+	return c.getRemoteFirst(ctx, key)
+}
+
+// getLocalFirst checks local cache first, then falls back to remote
+func (c *MultiTierCache) getLocalFirst(ctx context.Context, key CacheKey) (*CacheEntry, error) {
+	// Try local first
+	entry, err := c.local.Get(ctx, key)
+	if err == nil {
+		return entry, nil
+	}
+
+	// Fall back to remote if enabled and available
+	if !c.config.ReadFromRemote || c.remote == nil {
+		return nil, ErrCacheMiss
+	}
+
+	entry, err = c.remote.Get(ctx, key)
+	if err != nil {
+		return nil, err
+	}
+
+	// Warm local cache on remote hit
+	if c.config.WarmLocalOnRemoteHit {
+		if putErr := c.local.Put(ctx, entry); putErr != nil {
+			log.Printf("Failed to warm local cache: %v", putErr)
+		}
+	}
+
+	return entry, nil
+}
+
+// getRemoteFirst checks remote cache first, then falls back to local
+func (c *MultiTierCache) getRemoteFirst(ctx context.Context, key CacheKey) (*CacheEntry, error) {
+	// Try remote first if enabled and available
+	if c.config.ReadFromRemote && c.remote != nil {
+		entry, err := c.remote.Get(ctx, key)
+		if err == nil {
+			// Warm local cache on remote hit
+			if c.config.WarmLocalOnRemoteHit {
+				if putErr := c.local.Put(ctx, entry); putErr != nil {
+					log.Printf("Failed to warm local cache: %v", putErr)
+				}
+			}
+			return entry, nil
+		}
+	}
+
+	// Fall back to local
+	return c.local.Get(ctx, key)
+}
+
+// Put stores a cache entry in local and optionally remote caches
+func (c *MultiTierCache) Put(ctx context.Context, entry *CacheEntry) error {
+	// Always write to local
+	if err := c.local.Put(ctx, entry); err != nil {
+		return err
+	}
+
+	// Write to remote if enabled and available
+	if c.config.WriteToRemote && c.remote != nil {
+		if err := c.remote.Put(ctx, entry); err != nil {
+			// Log but don't fail - local write succeeded
+			log.Printf("Failed to write to remote cache: %v", err)
+		}
+	}
+
+	return nil
+}
+
+// Delete removes a cache entry from local and optionally remote caches
+func (c *MultiTierCache) Delete(ctx context.Context, key CacheKey) error {
+	// Delete from local
+	if err := c.local.Delete(ctx, key); err != nil {
+		return err
+	}
+
+	// Delete from remote if available
+	if c.remote != nil {
+		if err := c.remote.Delete(ctx, key); err != nil {
+			// Log but don't fail - local delete succeeded
+			log.Printf("Failed to delete from remote cache: %v", err)
+		}
+	}
+
+	return nil
+}
+
+// HasRemote returns true if a remote cache is configured
+func (c *MultiTierCache) HasRemote() bool {
+	return c.remote != nil
+}
+
+// Local returns the local cache manager
+func (c *MultiTierCache) Local() CacheManager {
+	return c.local
+}
+
+// Remote returns the remote cache manager (may be nil)
+func (c *MultiTierCache) Remote() CacheManager {
+	return c.remote
+}
+
+// Config returns the current configuration
+func (c *MultiTierCache) Config() MultiTierConfig {
+	return c.config
+}

--- a/internal/cache/multitier_test.go
+++ b/internal/cache/multitier_test.go
@@ -1,0 +1,324 @@
+// internal/cache/multitier_test.go
+package cache
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// mockCache implements CacheManager for testing
+type mockCache struct {
+	entries map[string]*CacheEntry
+	getErr  error
+	putErr  error
+}
+
+func newMockCache() *mockCache {
+	return &mockCache{entries: make(map[string]*CacheEntry)}
+}
+
+func (m *mockCache) Get(ctx context.Context, key CacheKey) (*CacheEntry, error) {
+	if m.getErr != nil {
+		return nil, m.getErr
+	}
+	entry, ok := m.entries[key.Hash()]
+	if !ok {
+		return nil, ErrCacheMiss
+	}
+	return entry, nil
+}
+
+func (m *mockCache) Put(ctx context.Context, entry *CacheEntry) error {
+	if m.putErr != nil {
+		return m.putErr
+	}
+	m.entries[entry.Key.Hash()] = entry
+	return nil
+}
+
+func (m *mockCache) Delete(ctx context.Context, key CacheKey) error {
+	delete(m.entries, key.Hash())
+	return nil
+}
+
+func TestMultiTierCache_GetLocalFirst(t *testing.T) {
+	local := newMockCache()
+	remote := newMockCache()
+
+	key := CacheKey{FileHash: "abc123", FilePath: "/test.go"}
+	entry := &CacheEntry{Key: key, Timestamp: time.Now().Unix()}
+
+	// Put in local only
+	local.entries[key.Hash()] = entry
+
+	cache := NewMultiTierCache(local, remote, DefaultMultiTierConfig())
+	ctx := context.Background()
+
+	got, err := cache.Get(ctx, key)
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if got.Key.FileHash != key.FileHash {
+		t.Errorf("Get() FileHash = %s, want %s", got.Key.FileHash, key.FileHash)
+	}
+}
+
+func TestMultiTierCache_GetFallbackToRemote(t *testing.T) {
+	local := newMockCache()
+	remote := newMockCache()
+
+	key := CacheKey{FileHash: "xyz789", FilePath: "/main.go"}
+	entry := &CacheEntry{Key: key, Timestamp: time.Now().Unix()}
+
+	// Put in remote only
+	remote.entries[key.Hash()] = entry
+
+	cache := NewMultiTierCache(local, remote, DefaultMultiTierConfig())
+	ctx := context.Background()
+
+	got, err := cache.Get(ctx, key)
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if got.Key.FileHash != key.FileHash {
+		t.Errorf("Get() FileHash = %s, want %s", got.Key.FileHash, key.FileHash)
+	}
+
+	// Verify local was warmed
+	if _, ok := local.entries[key.Hash()]; !ok {
+		t.Error("Get() did not warm local cache")
+	}
+}
+
+func TestMultiTierCache_GetMiss(t *testing.T) {
+	local := newMockCache()
+	remote := newMockCache()
+
+	key := CacheKey{FileHash: "nonexistent"}
+
+	cache := NewMultiTierCache(local, remote, DefaultMultiTierConfig())
+	ctx := context.Background()
+
+	_, err := cache.Get(ctx, key)
+	if err != ErrCacheMiss {
+		t.Errorf("Get() error = %v, want ErrCacheMiss", err)
+	}
+}
+
+func TestMultiTierCache_GetRemoteDisabled(t *testing.T) {
+	local := newMockCache()
+	remote := newMockCache()
+
+	key := CacheKey{FileHash: "xyz789"}
+	entry := &CacheEntry{Key: key, Timestamp: time.Now().Unix()}
+
+	// Put in remote only
+	remote.entries[key.Hash()] = entry
+
+	config := DefaultMultiTierConfig()
+	config.ReadFromRemote = false
+
+	cache := NewMultiTierCache(local, remote, config)
+	ctx := context.Background()
+
+	// Should not find it since remote is disabled
+	_, err := cache.Get(ctx, key)
+	if err != ErrCacheMiss {
+		t.Errorf("Get() error = %v, want ErrCacheMiss", err)
+	}
+}
+
+func TestMultiTierCache_GetRemoteFirst(t *testing.T) {
+	local := newMockCache()
+	remote := newMockCache()
+
+	key := CacheKey{FileHash: "remote-first"}
+	localEntry := &CacheEntry{Key: key, Results: nil, Timestamp: 1}
+	remoteEntry := &CacheEntry{Key: key, Results: nil, Timestamp: 2}
+
+	local.entries[key.Hash()] = localEntry
+	remote.entries[key.Hash()] = remoteEntry
+
+	config := DefaultMultiTierConfig()
+	config.PreferLocal = false
+
+	cache := NewMultiTierCache(local, remote, config)
+	ctx := context.Background()
+
+	got, err := cache.Get(ctx, key)
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+
+	// Should get remote entry (timestamp 2)
+	if got.Timestamp != 2 {
+		t.Errorf("Get() Timestamp = %d, want 2 (remote)", got.Timestamp)
+	}
+}
+
+func TestMultiTierCache_Put(t *testing.T) {
+	local := newMockCache()
+	remote := newMockCache()
+
+	key := CacheKey{FileHash: "newentry"}
+	entry := &CacheEntry{Key: key, Timestamp: time.Now().Unix()}
+
+	cache := NewMultiTierCache(local, remote, DefaultMultiTierConfig())
+	ctx := context.Background()
+
+	if err := cache.Put(ctx, entry); err != nil {
+		t.Fatalf("Put() error = %v", err)
+	}
+
+	// Verify in both caches
+	if _, ok := local.entries[key.Hash()]; !ok {
+		t.Error("Put() did not write to local cache")
+	}
+	if _, ok := remote.entries[key.Hash()]; !ok {
+		t.Error("Put() did not write to remote cache")
+	}
+}
+
+func TestMultiTierCache_PutRemoteDisabled(t *testing.T) {
+	local := newMockCache()
+	remote := newMockCache()
+
+	key := CacheKey{FileHash: "localonly"}
+	entry := &CacheEntry{Key: key, Timestamp: time.Now().Unix()}
+
+	config := DefaultMultiTierConfig()
+	config.WriteToRemote = false
+
+	cache := NewMultiTierCache(local, remote, config)
+	ctx := context.Background()
+
+	if err := cache.Put(ctx, entry); err != nil {
+		t.Fatalf("Put() error = %v", err)
+	}
+
+	// Verify only in local
+	if _, ok := local.entries[key.Hash()]; !ok {
+		t.Error("Put() did not write to local cache")
+	}
+	if _, ok := remote.entries[key.Hash()]; ok {
+		t.Error("Put() wrote to remote cache when disabled")
+	}
+}
+
+func TestMultiTierCache_PutRemoteError(t *testing.T) {
+	local := newMockCache()
+	remote := newMockCache()
+	remote.putErr = errors.New("remote error")
+
+	key := CacheKey{FileHash: "remotefails"}
+	entry := &CacheEntry{Key: key, Timestamp: time.Now().Unix()}
+
+	cache := NewMultiTierCache(local, remote, DefaultMultiTierConfig())
+	ctx := context.Background()
+
+	// Should succeed despite remote error
+	if err := cache.Put(ctx, entry); err != nil {
+		t.Fatalf("Put() error = %v, want nil (remote error should be logged)", err)
+	}
+
+	// Verify local was written
+	if _, ok := local.entries[key.Hash()]; !ok {
+		t.Error("Put() did not write to local cache")
+	}
+}
+
+func TestMultiTierCache_Delete(t *testing.T) {
+	local := newMockCache()
+	remote := newMockCache()
+
+	key := CacheKey{FileHash: "todelete"}
+	entry := &CacheEntry{Key: key, Timestamp: time.Now().Unix()}
+
+	local.entries[key.Hash()] = entry
+	remote.entries[key.Hash()] = entry
+
+	cache := NewMultiTierCache(local, remote, DefaultMultiTierConfig())
+	ctx := context.Background()
+
+	if err := cache.Delete(ctx, key); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+
+	// Verify deleted from both
+	if _, ok := local.entries[key.Hash()]; ok {
+		t.Error("Delete() did not remove from local cache")
+	}
+	if _, ok := remote.entries[key.Hash()]; ok {
+		t.Error("Delete() did not remove from remote cache")
+	}
+}
+
+func TestMultiTierCache_NoRemote(t *testing.T) {
+	local := newMockCache()
+
+	key := CacheKey{FileHash: "localonly"}
+	entry := &CacheEntry{Key: key, Timestamp: time.Now().Unix()}
+
+	// Create with nil remote
+	cache := NewMultiTierCache(local, nil, DefaultMultiTierConfig())
+	ctx := context.Background()
+
+	// Put should work
+	if err := cache.Put(ctx, entry); err != nil {
+		t.Fatalf("Put() error = %v", err)
+	}
+
+	// Get should work
+	got, err := cache.Get(ctx, key)
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if got.Key.FileHash != key.FileHash {
+		t.Errorf("Get() FileHash = %s, want %s", got.Key.FileHash, key.FileHash)
+	}
+
+	// HasRemote should be false
+	if cache.HasRemote() {
+		t.Error("HasRemote() = true, want false")
+	}
+}
+
+func TestMultiTierCache_Accessors(t *testing.T) {
+	local := newMockCache()
+	remote := newMockCache()
+	config := DefaultMultiTierConfig()
+
+	cache := NewMultiTierCache(local, remote, config)
+
+	if cache.Local() != local {
+		t.Error("Local() returned wrong cache")
+	}
+	if cache.Remote() != remote {
+		t.Error("Remote() returned wrong cache")
+	}
+	if cache.Config() != config {
+		t.Error("Config() returned wrong config")
+	}
+	if !cache.HasRemote() {
+		t.Error("HasRemote() = false, want true")
+	}
+}
+
+func TestDefaultMultiTierConfig(t *testing.T) {
+	config := DefaultMultiTierConfig()
+
+	if !config.WriteToRemote {
+		t.Error("WriteToRemote should be true by default")
+	}
+	if !config.ReadFromRemote {
+		t.Error("ReadFromRemote should be true by default")
+	}
+	if !config.PreferLocal {
+		t.Error("PreferLocal should be true by default")
+	}
+	if !config.WarmLocalOnRemoteHit {
+		t.Error("WarmLocalOnRemoteHit should be true by default")
+	}
+}

--- a/internal/cache/remote.go
+++ b/internal/cache/remote.go
@@ -1,0 +1,226 @@
+// internal/cache/remote.go
+package cache
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// RemoteCache implements CacheManager using a remote HTTP cache server
+type RemoteCache struct {
+	baseURL    string
+	httpClient *http.Client
+	token      string
+}
+
+// RemoteCacheOption configures a RemoteCache
+type RemoteCacheOption func(*RemoteCache)
+
+// WithHTTPClient sets a custom HTTP client
+func WithHTTPClient(client *http.Client) RemoteCacheOption {
+	return func(c *RemoteCache) {
+		c.httpClient = client
+	}
+}
+
+// WithToken sets the authentication token
+func WithToken(token string) RemoteCacheOption {
+	return func(c *RemoteCache) {
+		c.token = token
+	}
+}
+
+// WithTimeout sets the HTTP client timeout
+func WithTimeout(timeout time.Duration) RemoteCacheOption {
+	return func(c *RemoteCache) {
+		c.httpClient.Timeout = timeout
+	}
+}
+
+// NewRemoteCache creates a new remote cache client
+func NewRemoteCache(baseURL string, opts ...RemoteCacheOption) *RemoteCache {
+	c := &RemoteCache{
+		baseURL: baseURL,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+
+	for _, opt := range opts {
+		opt(c)
+	}
+
+	return c
+}
+
+// Get retrieves a cache entry from the remote server
+func (c *RemoteCache) Get(ctx context.Context, key CacheKey) (*CacheEntry, error) {
+	hash := key.Hash()
+	reqURL := fmt.Sprintf("%s/api/cache/%s", c.baseURL, url.PathEscape(hash))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+
+	c.setAuthHeader(req)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("executing request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, ErrCacheMiss
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var entry CacheEntry
+	if err := json.NewDecoder(resp.Body).Decode(&entry); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+
+	return &entry, nil
+}
+
+// Put stores a cache entry on the remote server
+func (c *RemoteCache) Put(ctx context.Context, entry *CacheEntry) error {
+	hash := entry.Key.Hash()
+	reqURL := fmt.Sprintf("%s/api/cache/%s", c.baseURL, url.PathEscape(hash))
+
+	data, err := json.Marshal(entry)
+	if err != nil {
+		return fmt.Errorf("encoding entry: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, reqURL, bytes.NewReader(data))
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+
+	c.setAuthHeader(req)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("executing request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
+	}
+
+	return nil
+}
+
+// Delete removes a cache entry from the remote server
+func (c *RemoteCache) Delete(ctx context.Context, key CacheKey) error {
+	hash := key.Hash()
+	reqURL := fmt.Sprintf("%s/api/cache/%s", c.baseURL, url.PathEscape(hash))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, reqURL, nil)
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+
+	c.setAuthHeader(req)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("executing request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// 404 is acceptable for delete - entry might already be gone
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusNotFound {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
+	}
+
+	return nil
+}
+
+// Stats retrieves cache statistics from the remote server
+func (c *RemoteCache) Stats(ctx context.Context) (*RemoteCacheStats, error) {
+	reqURL := fmt.Sprintf("%s/api/cache/stats", c.baseURL)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+
+	c.setAuthHeader(req)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("executing request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var stats RemoteCacheStats
+	if err := json.NewDecoder(resp.Body).Decode(&stats); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+
+	return &stats, nil
+}
+
+// Ping checks if the remote server is reachable
+func (c *RemoteCache) Ping(ctx context.Context) error {
+	reqURL := fmt.Sprintf("%s/api/health", c.baseURL)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+
+	c.setAuthHeader(req)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("server unreachable: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("server returned status %d", resp.StatusCode)
+	}
+
+	return nil
+}
+
+// setAuthHeader adds the authentication header if a token is configured
+func (c *RemoteCache) setAuthHeader(req *http.Request) {
+	if c.token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+}
+
+// RemoteCacheStats holds statistics from the remote cache server
+type RemoteCacheStats struct {
+	Entries   int64   `json:"entries"`
+	SizeBytes int64   `json:"size_bytes"`
+	HitRate   float64 `json:"hit_rate"`
+	Hits      int64   `json:"hits"`
+	Misses    int64   `json:"misses"`
+}

--- a/internal/cache/remote_test.go
+++ b/internal/cache/remote_test.go
@@ -1,0 +1,236 @@
+// internal/cache/remote_test.go
+package cache
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestRemoteCache_Get(t *testing.T) {
+	entry := &CacheEntry{
+		Key: CacheKey{
+			FileHash: "abc123",
+			FilePath: "/test.go",
+			Provider: "openrouter",
+			Model:    "claude-3",
+		},
+		Results:   nil,
+		Timestamp: time.Now().Unix(),
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("Expected GET, got %s", r.Method)
+		}
+		if r.Header.Get("Accept") != "application/json" {
+			t.Error("Expected Accept: application/json header")
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(entry)
+	}))
+	defer server.Close()
+
+	cache := NewRemoteCache(server.URL)
+	ctx := context.Background()
+
+	got, err := cache.Get(ctx, entry.Key)
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+
+	if got.Key.FileHash != entry.Key.FileHash {
+		t.Errorf("Get().Key.FileHash = %s, want %s", got.Key.FileHash, entry.Key.FileHash)
+	}
+}
+
+func TestRemoteCache_Get_NotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	cache := NewRemoteCache(server.URL)
+	ctx := context.Background()
+
+	_, err := cache.Get(ctx, CacheKey{FileHash: "missing"})
+	if err != ErrCacheMiss {
+		t.Errorf("Get() error = %v, want ErrCacheMiss", err)
+	}
+}
+
+func TestRemoteCache_Put(t *testing.T) {
+	var receivedEntry CacheEntry
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("Expected PUT, got %s", r.Method)
+		}
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Error("Expected Content-Type: application/json header")
+		}
+
+		json.NewDecoder(r.Body).Decode(&receivedEntry)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer server.Close()
+
+	cache := NewRemoteCache(server.URL)
+	ctx := context.Background()
+
+	entry := &CacheEntry{
+		Key: CacheKey{
+			FileHash: "xyz789",
+			FilePath: "/main.go",
+		},
+		Timestamp: time.Now().Unix(),
+	}
+
+	if err := cache.Put(ctx, entry); err != nil {
+		t.Fatalf("Put() error = %v", err)
+	}
+
+	if receivedEntry.Key.FileHash != entry.Key.FileHash {
+		t.Errorf("Server received FileHash = %s, want %s", receivedEntry.Key.FileHash, entry.Key.FileHash)
+	}
+}
+
+func TestRemoteCache_Delete(t *testing.T) {
+	deleted := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("Expected DELETE, got %s", r.Method)
+		}
+		deleted = true
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	cache := NewRemoteCache(server.URL)
+	ctx := context.Background()
+
+	if err := cache.Delete(ctx, CacheKey{FileHash: "todelete"}); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+
+	if !deleted {
+		t.Error("Delete() did not send request to server")
+	}
+}
+
+func TestRemoteCache_Delete_NotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	cache := NewRemoteCache(server.URL)
+	ctx := context.Background()
+
+	// Delete of nonexistent should succeed
+	if err := cache.Delete(ctx, CacheKey{FileHash: "nonexistent"}); err != nil {
+		t.Errorf("Delete() error = %v, want nil", err)
+	}
+}
+
+func TestRemoteCache_WithToken(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		if auth != "Bearer test-token" {
+			t.Errorf("Authorization = %s, want Bearer test-token", auth)
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	cache := NewRemoteCache(server.URL, WithToken("test-token"))
+	ctx := context.Background()
+
+	cache.Get(ctx, CacheKey{FileHash: "any"})
+}
+
+func TestRemoteCache_Ping(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/health" {
+			t.Errorf("Expected /api/health, got %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	cache := NewRemoteCache(server.URL)
+	ctx := context.Background()
+
+	if err := cache.Ping(ctx); err != nil {
+		t.Errorf("Ping() error = %v", err)
+	}
+}
+
+func TestRemoteCache_Ping_Failure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	cache := NewRemoteCache(server.URL)
+	ctx := context.Background()
+
+	if err := cache.Ping(ctx); err == nil {
+		t.Error("Ping() expected error for non-200 response")
+	}
+}
+
+func TestRemoteCache_Stats(t *testing.T) {
+	stats := &RemoteCacheStats{
+		Entries:   100,
+		SizeBytes: 1024000,
+		HitRate:   0.85,
+		Hits:      850,
+		Misses:    150,
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/cache/stats" {
+			t.Errorf("Expected /api/cache/stats, got %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(stats)
+	}))
+	defer server.Close()
+
+	cache := NewRemoteCache(server.URL)
+	ctx := context.Background()
+
+	got, err := cache.Stats(ctx)
+	if err != nil {
+		t.Fatalf("Stats() error = %v", err)
+	}
+
+	if got.Entries != stats.Entries {
+		t.Errorf("Stats().Entries = %d, want %d", got.Entries, stats.Entries)
+	}
+	if got.HitRate != stats.HitRate {
+		t.Errorf("Stats().HitRate = %f, want %f", got.HitRate, stats.HitRate)
+	}
+}
+
+func TestRemoteCache_ContextCancellation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	cache := NewRemoteCache(server.URL)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	_, err := cache.Get(ctx, CacheKey{FileHash: "any"})
+	if err == nil {
+		t.Error("Get() expected error for cancelled context")
+	}
+}

--- a/internal/cache/storage.go
+++ b/internal/cache/storage.go
@@ -1,0 +1,112 @@
+// internal/cache/storage.go
+package cache
+
+import (
+	"context"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Storage provides an abstraction for storing and retrieving cache data
+type Storage interface {
+	Get(ctx context.Context, key string) ([]byte, error)
+	Put(ctx context.Context, key string, data []byte) error
+	Delete(ctx context.Context, key string) error
+	List(ctx context.Context, prefix string) ([]string, error)
+}
+
+// LocalStorage implements Storage using the local filesystem
+type LocalStorage struct {
+	dir string
+}
+
+// NewLocalStorage creates a new local filesystem storage
+func NewLocalStorage(dir string) *LocalStorage {
+	return &LocalStorage{dir: dir}
+}
+
+// keyPath converts a cache key to a filesystem path
+func (s *LocalStorage) keyPath(key string) string {
+	return filepath.Join(s.dir, key+".json")
+}
+
+// Get retrieves data for the given key
+func (s *LocalStorage) Get(ctx context.Context, key string) ([]byte, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	data, err := os.ReadFile(s.keyPath(key))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, ErrCacheMiss
+		}
+		return nil, err
+	}
+	return data, nil
+}
+
+// Put stores data for the given key
+func (s *LocalStorage) Put(ctx context.Context, key string, data []byte) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(s.dir, 0755); err != nil {
+		return err
+	}
+
+	return os.WriteFile(s.keyPath(key), data, 0644)
+}
+
+// Delete removes data for the given key
+func (s *LocalStorage) Delete(ctx context.Context, key string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	err := os.Remove(s.keyPath(key))
+	if err != nil && os.IsNotExist(err) {
+		return nil // Not an error if already deleted
+	}
+	return err
+}
+
+// List returns all keys matching the given prefix
+func (s *LocalStorage) List(ctx context.Context, prefix string) ([]string, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	var keys []string
+	err := filepath.WalkDir(s.dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		// Extract key from path (remove dir prefix and .json suffix)
+		relPath, err := filepath.Rel(s.dir, path)
+		if err != nil {
+			return err
+		}
+		key := strings.TrimSuffix(relPath, ".json")
+		if prefix == "" || strings.HasPrefix(key, prefix) {
+			keys = append(keys, key)
+		}
+		return nil
+	})
+
+	if err != nil && os.IsNotExist(err) {
+		return nil, nil // Empty list if directory doesn't exist
+	}
+	return keys, err
+}
+
+// Dir returns the storage directory path
+func (s *LocalStorage) Dir() string {
+	return s.dir
+}

--- a/internal/cache/storage_test.go
+++ b/internal/cache/storage_test.go
@@ -1,0 +1,177 @@
+// internal/cache/storage_test.go
+package cache
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLocalStorage_PutAndGet(t *testing.T) {
+	dir := t.TempDir()
+	storage := NewLocalStorage(dir)
+	ctx := context.Background()
+
+	key := "test-key"
+	data := []byte(`{"test": "data"}`)
+
+	// Put data
+	if err := storage.Put(ctx, key, data); err != nil {
+		t.Fatalf("Put() error = %v", err)
+	}
+
+	// Get data
+	got, err := storage.Get(ctx, key)
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+
+	if string(got) != string(data) {
+		t.Errorf("Get() = %s, want %s", got, data)
+	}
+}
+
+func TestLocalStorage_GetMissing(t *testing.T) {
+	dir := t.TempDir()
+	storage := NewLocalStorage(dir)
+	ctx := context.Background()
+
+	_, err := storage.Get(ctx, "nonexistent")
+	if err != ErrCacheMiss {
+		t.Errorf("Get() error = %v, want ErrCacheMiss", err)
+	}
+}
+
+func TestLocalStorage_Delete(t *testing.T) {
+	dir := t.TempDir()
+	storage := NewLocalStorage(dir)
+	ctx := context.Background()
+
+	key := "test-key"
+	data := []byte(`{"test": "data"}`)
+
+	// Put data
+	if err := storage.Put(ctx, key, data); err != nil {
+		t.Fatalf("Put() error = %v", err)
+	}
+
+	// Delete data
+	if err := storage.Delete(ctx, key); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+
+	// Verify deleted
+	_, err := storage.Get(ctx, key)
+	if err != ErrCacheMiss {
+		t.Errorf("Get() after delete error = %v, want ErrCacheMiss", err)
+	}
+}
+
+func TestLocalStorage_DeleteNonexistent(t *testing.T) {
+	dir := t.TempDir()
+	storage := NewLocalStorage(dir)
+	ctx := context.Background()
+
+	// Delete nonexistent key should not error
+	if err := storage.Delete(ctx, "nonexistent"); err != nil {
+		t.Errorf("Delete() error = %v, want nil", err)
+	}
+}
+
+func TestLocalStorage_List(t *testing.T) {
+	dir := t.TempDir()
+	storage := NewLocalStorage(dir)
+	ctx := context.Background()
+
+	// Put multiple keys
+	keys := []string{"key1", "key2", "prefix-a", "prefix-b"}
+	for _, k := range keys {
+		if err := storage.Put(ctx, k, []byte("data")); err != nil {
+			t.Fatalf("Put(%s) error = %v", k, err)
+		}
+	}
+
+	// List all
+	all, err := storage.List(ctx, "")
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(all) != 4 {
+		t.Errorf("List() returned %d keys, want 4", len(all))
+	}
+
+	// List with prefix
+	prefixed, err := storage.List(ctx, "prefix")
+	if err != nil {
+		t.Fatalf("List(prefix) error = %v", err)
+	}
+	if len(prefixed) != 2 {
+		t.Errorf("List(prefix) returned %d keys, want 2", len(prefixed))
+	}
+}
+
+func TestLocalStorage_ListEmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	nonexistent := filepath.Join(dir, "nonexistent")
+	storage := NewLocalStorage(nonexistent)
+	ctx := context.Background()
+
+	keys, err := storage.List(ctx, "")
+	if err != nil {
+		t.Errorf("List() error = %v, want nil", err)
+	}
+	if keys != nil && len(keys) != 0 {
+		t.Errorf("List() returned %v, want empty", keys)
+	}
+}
+
+func TestLocalStorage_ContextCancellation(t *testing.T) {
+	dir := t.TempDir()
+	storage := NewLocalStorage(dir)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	// Operations should fail with context error
+	if _, err := storage.Get(ctx, "key"); err != context.Canceled {
+		t.Errorf("Get() error = %v, want context.Canceled", err)
+	}
+
+	if err := storage.Put(ctx, "key", []byte("data")); err != context.Canceled {
+		t.Errorf("Put() error = %v, want context.Canceled", err)
+	}
+
+	if err := storage.Delete(ctx, "key"); err != context.Canceled {
+		t.Errorf("Delete() error = %v, want context.Canceled", err)
+	}
+
+	if _, err := storage.List(ctx, ""); err != context.Canceled {
+		t.Errorf("List() error = %v, want context.Canceled", err)
+	}
+}
+
+func TestLocalStorage_Dir(t *testing.T) {
+	dir := "/some/path"
+	storage := NewLocalStorage(dir)
+	if storage.Dir() != dir {
+		t.Errorf("Dir() = %s, want %s", storage.Dir(), dir)
+	}
+}
+
+func TestLocalStorage_CreatesDirectory(t *testing.T) {
+	dir := t.TempDir()
+	subdir := filepath.Join(dir, "subdir", "cache")
+	storage := NewLocalStorage(subdir)
+	ctx := context.Background()
+
+	// Put should create the directory
+	if err := storage.Put(ctx, "key", []byte("data")); err != nil {
+		t.Fatalf("Put() error = %v", err)
+	}
+
+	// Verify directory was created
+	if _, err := os.Stat(subdir); os.IsNotExist(err) {
+		t.Error("Put() did not create directory")
+	}
+}

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -24,6 +24,15 @@ func SystemDefaults() *Config {
 			},
 		},
 		Persona: "code-reviewer",
+		RemoteCache: RemoteCacheConfig{
+			Enabled: false,
+			Strategy: CacheStrategy{
+				WriteToRemote:        true,
+				ReadFromRemote:       true,
+				PreferLocal:          true,
+				WarmLocalOnRemoteHit: true,
+			},
+		},
 		LSP: LSPConfig{
 			Watcher: WatcherConfig{
 				DebounceDuration: "5m",


### PR DESCRIPTION
## Summary

Add a CI workflow that uses Gavel to analyze its own PRs — dogfooding the tool in CI.

### Two jobs:

**`gate` (always runs on PRs to main):**
- Downloads the latest **released** Gavel binary
- Runs `gavel analyze --diff` on the PR diff
- Fails CI (`exit 1`) if the verdict is `reject`
- Writes decision, reason, and findings to the GitHub Step Summary

**`benchmark` (only when PR title contains `/benchmark`):**
- Builds Gavel **from source** (the PR's code)
- Also downloads the released binary
- Runs both on the same diff
- Produces a side-by-side comparison table in the Step Summary

### New files:
- `.github/workflows/gavel.yml` — the workflow
- `.github/policies.yaml` — CI-specific Gavel config (OpenRouter + claude-haiku-4-5)

### Prerequisites:
Add `OPENROUTER_API_KEY` as a repository secret.