### PR TITLE
ci: add Gavel AI Code Review workflow with SARIF upload

### DIFF
--- a/.github/workflows/gavel.yml
+++ b/.github/workflows/gavel.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: read
   pull-requests: read
+  security-events: write
 
 jobs:
   # Always runs: analyze PR diff with the latest released Gavel binary
@@ -80,6 +81,13 @@ jobs:
           fi
 
           echo "✅ Gavel decision: ${DECISION}"
+
+      - name: Upload SARIF to GitHub Code Scanning
+        uses: github/codeql-action/upload-sarif@v4
+        if: always() && env.SKIP_ANALYSIS != 'true'
+        with:
+          sarif_file: /tmp/gavel-results/
+          category: gavel
 
   # Only runs when PR title contains /benchmark
   benchmark:


### PR DESCRIPTION
Add GitHub Actions workflow that runs Gavel analysis on PRs and uploads SARIF results to GitHub Code Scanning for native PR diff annotations.

**What it does:**
- Downloads the latest Gavel release binary
- Gets the PR diff via `gh pr diff`
- Runs `gavel analyze` against configured policies
- Uploads SARIF to Code Scanning with category `gavel`

**Requirements:**
- `OPENROUTER_API_KEY` repository secret (or `ANTHROPIC_API_KEY` if using Anthropic)
- Code Scanning enabled under Settings > Code security and analysis

Follows the guide in `docs/guides/ci-pr-gating.md`.