### PR TITLE
Update tune-review skill to use gavel harness

### DIFF
--- a/.claude/skills/tune-review/SKILL.md
+++ b/.claude/skills/tune-review/SKILL.md
@@ -5,7 +5,7 @@ description: Use when tuning Gavel's LLM review prompts - modifying persona text
 
 # Tune Review
 
-Run A/B evaluations to measure the effect of prompt changes on Gavel's LLM analysis quality.
+Run A/B evaluations to measure the effect of prompt changes on Gavel's LLM analysis quality using `gavel harness`.
 
 **Core principle:** Never ship a prompt change based on a single run. LLM nondeterminism makes single-run comparisons unreliable. Always use multi-run averaging.
 
@@ -19,15 +19,18 @@ Run A/B evaluations to measure the effect of prompt changes on Gavel's LLM analy
 
 ## What Can Vary
 
-| Knob | Location | How to Vary |
-|------|----------|-------------|
-| Persona text | `internal/analyzer/personas.go` | Edit prompt constants, rebuild |
-| Applicability filter | `internal/analyzer/personas.go` | Edit `ApplicabilityFilterPrompt`, rebuild |
-| Filter on/off | `.gavel/policies.yaml` | `strict_filter: true/false` (script toggles this) |
-| Persona selection | `.gavel/policies.yaml` | `persona: code-reviewer\|architect\|security` |
-| Policy instructions | `.gavel/policies.yaml` | Edit `policies:` section |
-| Model | `.gavel/policies.yaml` | Change provider/model |
-| BAML template | `baml_src/analyze.baml` | Edit template, run `task generate`, rebuild |
+Each variant in the harness config can override any combination of these knobs:
+
+| Knob | Variant Field | Notes |
+|------|---------------|-------|
+| Persona selection | `persona: code-reviewer\|architect\|security` | Switches persona prompt |
+| Filter on/off | `strict_filter: true/false` | Toggles applicability filter |
+| Extra prompt text | `prompt_add: "..."` | Appended to persona prompt |
+| Replace prompt | `prompt_replace: "..."` | Completely replaces persona prompt |
+| Policy instructions | `policies:` section | Merged with base config policies |
+| Model/provider | `provider:` section | Override provider name and/or model |
+
+For changes that require code edits (persona text, filter logic, BAML templates), rebuild between variants — see "Code Change Workflow" below.
 
 ## Process
 
@@ -36,71 +39,107 @@ Run A/B evaluations to measure the effect of prompt changes on Gavel's LLM analy
 Decide what you're changing and what you're holding constant. Write down your hypothesis:
 > "Adding X to the prompt should reduce Y by Z% without increasing high-confidence errors."
 
-### 2. Set Up Eval Environment
+### 2. Create a Variants Config
 
-```bash
-mkdir -p /tmp/gavel-eval/.gavel
-cp scripts/eval/example-policies.yaml /tmp/gavel-eval/.gavel/policies.yaml
-# Configure provider section for your LLM backend
+Create a YAML file defining your experiment. See `scripts/eval/example-variants.yaml` for a full reference.
+
+```yaml
+runs: 3
+baseline: baseline
+
+# Local packages
+targets:
+  - path: internal/mcp
+  - path: internal/evaluator
+
+# Or external repos
+# repos:
+#   - name: juice-shop
+#     url: https://github.com/juice-shop/juice-shop
+#     branch: master
+# targets:
+#   - repo: juice-shop
+#     paths: [server, frontend/src/app]
+
+variants:
+  - name: baseline
+    description: "Current configuration"
+    persona: security
+    strict_filter: true
+
+  - name: variant
+    description: "With proposed change"
+    persona: security
+    strict_filter: true
+    prompt_add: "Pay special attention to injection vulnerabilities."
 ```
 
-### 3. Build Baseline Binary
+### 3. Build and Run
 
 ```bash
 task build
-cp dist/gavel /tmp/gavel-eval/gavel-baseline
+gavel harness run variants.yaml --output results.jsonl
 ```
 
-### 4. Run Baseline Experiment
+### 4. Summarize and Compare
 
 ```bash
-./scripts/eval/run-experiment.sh /tmp/gavel-eval/gavel-baseline /tmp/gavel-eval
-mv /tmp/gavel-eval/experiment-results.jsonl /tmp/gavel-eval/baseline.jsonl
+gavel harness summarize results.jsonl --baseline baseline
 ```
 
-### 5. Make Your Change
-
-Edit the prompt/template, then rebuild:
-
+For machine-readable output:
 ```bash
-# If changing Go code (personas, filter):
-task build
-cp dist/gavel /tmp/gavel-eval/gavel-variant
-
-# If changing BAML templates:
-task generate && task build
-cp dist/gavel /tmp/gavel-eval/gavel-variant
+gavel harness summarize results.jsonl --baseline baseline --format json
+gavel harness summarize results.jsonl --baseline baseline --format yaml
 ```
 
-### 6. Run Variant Experiment
-
-```bash
-./scripts/eval/run-experiment.sh /tmp/gavel-eval/gavel-variant /tmp/gavel-eval
-mv /tmp/gavel-eval/experiment-results.jsonl /tmp/gavel-eval/variant.jsonl
-```
-
-### 7. Compare Results
-
-```bash
-echo "=== BASELINE ===" && python3 scripts/eval/summarize-results.py /tmp/gavel-eval/baseline.jsonl
-echo "=== VARIANT ===" && python3 scripts/eval/summarize-results.py /tmp/gavel-eval/variant.jsonl
-```
-
-### 8. Decide
+### 5. Decide
 
 Apply the decision framework below, then commit or discard.
 
-## Shortcut: Filter Toggle Only
+## Code Change Workflow
 
-When only toggling `strict_filter` (no code changes needed), a single experiment run captures both conditions:
+When the change requires editing Go code or BAML templates (not just config knobs), you need separate binaries:
 
 ```bash
+# 1. Build baseline binary
 task build
-./scripts/eval/run-experiment.sh ./dist/gavel /tmp/gavel-eval
-python3 scripts/eval/summarize-results.py /tmp/gavel-eval/experiment-results.jsonl
+cp dist/gavel /tmp/gavel-baseline
+
+# 2. Make your code change
+# Edit personas.go, analyze.baml, etc.
+# If BAML: task generate && task build
+# If Go only: task build
+cp dist/gavel /tmp/gavel-variant
+
+# 3. Run baseline experiment
+GAVEL_BINARY=/tmp/gavel-baseline gavel harness run variants.yaml -o baseline.jsonl
+
+# 4. Run variant experiment
+GAVEL_BINARY=/tmp/gavel-variant gavel harness run variants.yaml -o variant.jsonl
+
+# 5. Compare
+gavel harness summarize baseline.jsonl
+gavel harness summarize variant.jsonl
 ```
 
-The script toggles `strict_filter` between `true`/`false` automatically.
+## CLI Reference
+
+### `gavel harness run <variants.yaml>`
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--runs` | `-n` | From config or 3 | Number of runs per variant |
+| `--output` | `-o` | `experiment-results-<timestamp>.jsonl` | Output JSONL file path |
+| `--packages` | | From config | Override target packages |
+| `--config` | | `.gavel/policies.yaml` | Base config file path |
+
+### `gavel harness summarize <results.jsonl>`
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--baseline` | | (none) | Baseline variant name for delta calculations |
+| `--format` | `-f` | `text` | Output format: `text`, `json`, or `yaml` |
 
 ## Decision Framework
 
@@ -111,31 +150,32 @@ The script toggles `strict_filter` between `true`/`false` automatically.
 | High-conf errors Δ > +15% | Confidence inflation | Bad — model is compensating, prompt is confusing |
 | High-conf errors Δ < -15% | Real issues suppressed | Bad — filter too aggressive |
 | Instant findings Δ ≠ 0 | Control metric shifted | Bug — instant tier shouldn't change |
-| Std dev > mean Δ | High variance | Inconclusive — increase RUNS |
+| Std dev > mean Δ | High variance | Inconclusive — increase runs |
 
 **Ship when:** LLM delta is negative, high-conf errors are stable (±15%), and variance is low enough that the delta exceeds 2× std dev.
 
 ## Increasing Confidence
 
-- **More runs:** `RUNS=5` or `RUNS=10` reduces variance
-- **More packages:** Add packages to increase sample size per run
-- **Different models:** Test on multiple models to ensure prompt isn't model-specific
+- **More runs:** `--runs 5` or `--runs 10` reduces variance
+- **More targets:** Add targets to increase sample size per run
+- **External repos:** Use `repos:` to test against real-world codebases (e.g., OWASP Juice Shop)
+- **Different models:** Add model variants to ensure prompt isn't model-specific
 
 ## Key Files
 
-- `scripts/eval/run-experiment.sh` — Experiment runner
-- `scripts/eval/summarize-results.py` — Results summarizer
-- `scripts/eval/example-policies.yaml` — Config template
+- `scripts/eval/example-variants.yaml` — Full harness config example
+- `scripts/eval/juice-shop-security.yaml` — Ready-to-use security calibration config
+- `internal/harness/` — Harness implementation
 - `internal/analyzer/personas.go` — Persona prompts + applicability filter
 - `baml_src/analyze.baml` — BAML analysis template
-- `docs/evaluation-methodology.md` — Full methodology documentation
 
 ## Common Mistakes
 
 | Mistake | Fix |
 |---------|-----|
-| Single-run comparison | Always use RUNS≥3; initial tests showed 46% apparent improvement was actually 12% |
+| Single-run comparison | Always use runs≥3; initial tests showed 46% apparent improvement was actually 12% |
 | Changing multiple knobs at once | Vary one thing at a time to isolate effects |
 | Forgetting to rebuild after code changes | `task build` (or `task generate && task build` for BAML) |
-| Using the same eval dir without clearing results | Move/rename old JSONL before re-running |
-| Evaluating on trivial code | Use real packages with meaningful logic |
+| Using same output file without renaming | Use distinct `-o` paths or rename old JSONL before re-running |
+| Evaluating on trivial code | Use real packages or external repos with meaningful logic |
+| Not setting `GAVEL_BINARY` for code changes | Without it, harness uses `gavel` from PATH — both variants run the same binary |


### PR DESCRIPTION
## Summary
- Replace old `scripts/eval/run-experiment.sh` + `summarize-results.py` workflow with `gavel harness run` and `gavel harness summarize`
- Update "What Can Vary" table to reflect harness variant fields (`prompt_add`, `prompt_replace`, `provider`, etc.)
- Add CLI reference section and code change workflow using `GAVEL_BINARY` env var

## Test plan
- [ ] Verify skill loads correctly via `/tune-review`
- [ ] Confirm referenced commands (`gavel harness run`, `gavel harness summarize`) match current implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)