### PR TITLE
Fix path hallucination: prepend filename to LLM code input

### DIFF
--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -80,7 +80,15 @@ func (a *Analyzer) Analyze(ctx context.Context, artifacts []input.Artifact, poli
 	var allResults []sarif.Result
 
 	for _, art := range artifacts {
-		findings, err := a.client.AnalyzeCode(ctx, art.Content, policyText, personaPrompt, a.additionalContext)
+		// Prepend the filename so the LLM knows which file it's analyzing.
+		// Without this, models hallucinate conventional filenames (e.g. "handlers.go"
+		// instead of the actual "server.go"), causing ~50% of findings to reference
+		// nonexistent paths. See https://github.com/chris-regnier/gavel/issues/34.
+		code := art.Content
+		if art.Path != "" {
+			code = fmt.Sprintf("// File: %s\n%s", art.Path, art.Content)
+		}
+		findings, err := a.client.AnalyzeCode(ctx, code, policyText, personaPrompt, a.additionalContext)
 		if err != nil {
 			return nil, fmt.Errorf("analyzing %s: %w", art.Path, err)
 		}

--- a/internal/analyzer/analyzer_test.go
+++ b/internal/analyzer/analyzer_test.go
@@ -10,11 +10,13 @@ import (
 )
 
 type mockBAMLClient struct {
-	findings []Finding
-	err      error
+	findings   []Finding
+	err        error
+	lastCode   string // captures the code arg from the most recent call
 }
 
 func (m *mockBAMLClient) AnalyzeCode(ctx context.Context, code string, policies string, personaPrompt string, additionalContext string) ([]Finding, error) {
+	m.lastCode = code
 	return m.findings, m.err
 }
 
@@ -83,6 +85,51 @@ func TestAnalyzer_SkipsDisabledPolicies(t *testing.T) {
 	}
 	if results != nil {
 		t.Errorf("expected nil results for all-disabled policies, got %v", results)
+	}
+}
+
+func TestAnalyzer_PrependsFilePathToCode(t *testing.T) {
+	mock := &mockBAMLClient{findings: nil}
+	a := NewAnalyzer(mock)
+
+	artifacts := []input.Artifact{
+		{Path: "pkg/foo.go", Content: "package pkg\n", Kind: input.KindFile},
+	}
+	policies := map[string]config.Policy{
+		"rule": {Severity: "warning", Instruction: "check", Enabled: true},
+	}
+
+	_, err := a.Analyze(context.Background(), artifacts, policies, "persona")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.HasPrefix(mock.lastCode, "// File: pkg/foo.go\n") {
+		t.Errorf("expected code to start with file path header, got %q", mock.lastCode[:min(len(mock.lastCode), 60)])
+	}
+	if !strings.Contains(mock.lastCode, "package pkg") {
+		t.Error("expected original content to be preserved after the header")
+	}
+}
+
+func TestAnalyzer_EmptyPathSkipsHeader(t *testing.T) {
+	mock := &mockBAMLClient{findings: nil}
+	a := NewAnalyzer(mock)
+
+	artifacts := []input.Artifact{
+		{Path: "", Content: "package pkg\n", Kind: input.KindFile},
+	}
+	policies := map[string]config.Policy{
+		"rule": {Severity: "warning", Instruction: "check", Enabled: true},
+	}
+
+	_, err := a.Analyze(context.Background(), artifacts, policies, "persona")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if strings.HasPrefix(mock.lastCode, "// File:") {
+		t.Error("expected no file path header for empty path")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Prepends `// File: <path>` header to code content sent to the LLM in `Analyzer.Analyze()`, so the model knows which file it's analyzing
- Without this, models (especially smaller ones like `qwen2.5-coder:7b`) hallucinate conventional filenames (~50% of findings reference nonexistent paths)
- Skips the header when `art.Path` is empty

Fixes #34

## Test plan

- [x] New test `TestAnalyzer_PrependsFilePathToCode` verifies the header is prepended
- [x] New test `TestAnalyzer_EmptyPathSkipsHeader` verifies no header for empty paths
- [x] All existing analyzer tests pass
- [ ] Run A/B evaluation with the eval framework to measure reduction in path hallucination

🤖 Generated with [Claude Code](https://claude.com/claude-code)