### PR TITLE
fix: add language-safety check to applicability filter

### DIFF
--- a/internal/analyzer/personas.go
+++ b/internal/analyzer/personas.go
@@ -99,7 +99,11 @@ Before reporting any finding, apply this applicability test:
    an actual problem? If it is purely speculative ("this might not be
    thread-safe", "this could theoretically fail"), do not report it.
 
-Do not report findings that fail either test.
+3. LANGUAGE SAFETY: If the language or framework already prevents the issue
+   (e.g. parameterized queries, ownership/borrow checking, derive macros,
+   garbage collection), it is not a real finding. Do not report it.
+
+Do not report findings that fail any of these tests.
 ===== END FILTER =====`
 
 // GetPersonaPrompt returns the system prompt string for the given persona.

--- a/scripts/eval/rust-false-positives.yaml
+++ b/scripts/eval/rust-false-positives.yaml
@@ -1,0 +1,48 @@
+# Rust False Positive Evaluation Harness
+#
+# Tests the language-aware applicability filter against a real Rust workspace
+# to measure reduction in false positives on idiomatic Rust patterns.
+#
+# Issue: https://github.com/chris-regnier/gavel/issues/41
+#
+# Usage (code change workflow):
+#   GAVEL_BINARY=/tmp/gavel-baseline gavel harness run scripts/eval/rust-false-positives.yaml -o baseline.jsonl
+#   GAVEL_BINARY=/tmp/gavel-variant gavel harness run scripts/eval/rust-false-positives.yaml -o variant.jsonl
+#   gavel harness summarize baseline.jsonl
+#   gavel harness summarize variant.jsonl
+
+runs: 3
+baseline: security_baseline
+
+repos:
+  - name: veil
+    url: https://github.com/chris-regnier/veil
+    branch: main
+    depth: 1
+
+targets:
+  # canvas-store: sqlx parameterized queries (SQL injection FPs)
+  - repo: veil
+    paths:
+      - canvas/crates/canvas-store/src
+  # canvas-types: derive macros, HashMap::new() (memory/type FPs)
+  - repo: veil
+    paths:
+      - canvas/crates/canvas-types/src
+  # canvas-bus: RwLock::read() vs write() (lock FPs)
+  - repo: veil
+    paths:
+      - canvas/crates/canvas-bus/src
+
+variants:
+  # Security persona - had sqlx injection FPs
+  - name: security_baseline
+    description: "Security persona (tests sqlx injection FPs)"
+    persona: security
+    strict_filter: true
+
+  # Code reviewer persona - had derive macro, memory, lock FPs
+  - name: reviewer_baseline
+    description: "Code reviewer persona (tests derive/memory/lock FPs)"
+    persona: code-reviewer
+    strict_filter: true


### PR DESCRIPTION
## Summary
- Adds a third applicability test ("LANGUAGE SAFETY") to the filter prompt that instructs the LLM to suppress findings when the language or framework already prevents the issue
- Targets the false positive categories from #41: sqlx parameterized queries flagged as injection, derive/attribute macros ignored, ownership-based memory safety misunderstood, RwLock read/write semantics confused
- Includes `scripts/eval/rust-false-positives.yaml` harness config for reproducible A/B evaluation against the Canvas Framework Rust workspace

## A/B Evaluation Results

Tested two approaches: verbose (language-specific enumeration) and concise (single principle). Verbose **made things worse** (+15% LLM findings, +48% hi-conf errors on reviewer). Concise performed well:

**Security persona (primary concern):**
| Metric | Baseline | Concise | Delta |
|--------|----------|---------|-------|
| LLM findings | 6.0 ±2.4 | 5.2 ±2.2 | **-13.3%** |
| Hi-conf errors | 3.8 ±1.9 | 3.1 ±1.8 | **-18.4%** |

**Code reviewer persona:**
| Metric | Baseline | Concise | Delta |
|--------|----------|---------|-------|
| LLM findings | 6.0 ±3.5 | 4.7 ±2.7 | **-21.7%** |

3 runs × 3 crates × 2 personas = 18 runs per condition, using `gpt-oss:20b` via Ollama.

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [x] Persona tests pass including filter content assertions
- [x] A/B harness evaluation shows improvement on security persona
- [ ] Verify no regression on non-Rust codebases (can re-run juice-shop harness)

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)