### PR TITLE
ci: improve docs workflow with PR validation and manual trigger

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [main]
     paths: ['docs/**']
+  pull_request:
+    branches: [main]
+    paths: ['docs/**']
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -15,10 +19,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -29,5 +30,13 @@ jobs:
         with:
           path: docs
 
+  deploy:
+    needs: build
+    if: github.event_name != 'pull_request'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
       - id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

- Split docs workflow into separate build and deploy jobs
- Add `pull_request` trigger so PRs touching `docs/` validate the build artifact
- Add `workflow_dispatch` for manual triggering from the Actions tab
- Deploy only runs on push to `main` (not on PRs)

## Context

PR #53 added the docs site and was auto-merged before GitHub Pages was enabled. This PR improves the workflow so it can be triggered manually to deploy, and validates docs builds on future PRs.

## Setup required

Enable GitHub Pages: **Settings > Pages > Source: GitHub Actions**

Then either:
- Merge this PR (deploy triggers on push to main), or
- Trigger manually from **Actions > Deploy Docs > Run workflow**

## Test plan

- [ ] Enable GitHub Pages in repo settings
- [ ] Merge PR and verify deploy workflow runs
- [ ] Confirm site is live at https://chris-regnier.github.io/gavel/

🤖 Generated with [Claude Code](https://claude.com/claude-code)