### PR TITLE
docs: add guide for gavel create commands

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -37,3 +37,4 @@ judge:   FileStore → Rego Evaluator → Verdict
 - **[Try on Open Source](guides/try-on-open-source.md)** — Run Gavel on real repositories
 - **[Gate PRs with CI](guides/ci-pr-gating.md)** — Automate code review on every PR
 - **[Editor Integration](guides/editor-integration.md)** — See findings inline in VS Code or Neovim
+- **[Generating Configuration](guides/generating-config.md)** — Create policies, rules, and personas with AI

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -7,6 +7,7 @@
   - [Try on Open Source](guides/try-on-open-source.md)
   - [Gate PRs with CI](guides/ci-pr-gating.md)
   - [Editor Integration](guides/editor-integration.md)
+  - [Generating Configuration](guides/generating-config.md)
 
 - **Configuration**
   - [Providers](PROVIDERS.md)

--- a/docs/guides/generating-config.md
+++ b/docs/guides/generating-config.md
@@ -1,0 +1,178 @@
+# Generating Configuration with AI
+
+Gavel can generate policies, rules, personas, and complete configurations from natural language descriptions using an LLM. This is useful for bootstrapping a new project or creating custom analysis components without writing YAML by hand.
+
+## Prerequisites
+
+All generation commands require the `OPENROUTER_API_KEY` environment variable:
+
+```bash
+export OPENROUTER_API_KEY=sk-or-...
+```
+
+## Quick Start
+
+```bash
+# Generate a complete config for your project
+gavel create config "Go microservices with PostgreSQL, focus on security and error handling"
+
+# Generate a single policy
+gavel create policy "Check that all public functions have documentation comments"
+
+# Generate a regex-based rule
+gavel create rule --category=security "Detect hardcoded JWT secrets in Go code"
+
+# Generate a custom persona
+gavel create persona "A React expert who focuses on hooks and performance"
+
+# Launch the interactive wizard
+gavel create wizard
+```
+
+## Commands
+
+### `create policy`
+
+Generates a policy from a natural language description. Policies are high-level instructions that tell the LLM what to look for during analysis.
+
+```bash
+gavel create policy "Ensure all error returns include context wrapping"
+```
+
+Output (YAML):
+
+```yaml
+wrap_error_returns:
+  description: Check that error returns wrap context with fmt.Errorf or errors.Wrap
+  severity: warning
+  instruction: >-
+    Look for functions that return errors without adding context. Every error
+    return should wrap the original error with additional context about what
+    operation failed, using fmt.Errorf with %w or a wrapping library.
+  enabled: true
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `-o`, `--output` | Write to file instead of stdout | stdout |
+
+### `create rule`
+
+Generates a regex-based rule with CWE/OWASP references, confidence scores, and remediation guidance.
+
+```bash
+gavel create rule --category=security --languages=go,python \
+  "Detect SQL queries built with string concatenation"
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `-o`, `--output` | Write to file instead of stdout | stdout |
+| `-c`, `--category` | Rule category: `security`, `reliability`, `maintainability` | `maintainability` |
+| `-l`, `--languages` | Target languages (comma-separated) | `any` |
+
+Generated rules follow the ID convention `CUSTOM-S001` (security), `CUSTOM-R001` (reliability), `CUSTOM-M001` (maintainability).
+
+### `create persona`
+
+Generates a custom analysis persona with a complete system prompt, including role definition, focus areas, tone, and confidence guidance.
+
+```bash
+gavel create persona "A database expert who focuses on query performance and ORM anti-patterns"
+```
+
+Output (YAML):
+
+```yaml
+name: database-expert
+display_name: Database Expert
+system_prompt: |
+  You are a database performance specialist with deep expertise in SQL optimization,
+  ORM usage patterns, and data access layer design...
+
+  FOCUS AREAS:
+  - N+1 query patterns and eager loading opportunities
+  - Missing indexes on frequently queried columns
+  ...
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `-o`, `--output` | Write to file instead of stdout | stdout |
+
+The generator extracts focus areas from your description automatically. Keywords like "React", "performance", "security", "API", "database", "testing", "Go", and "Python" guide the focus areas.
+
+### `create config`
+
+Generates a complete `.gavel/policies.yaml` with provider settings, a persona, and starter policies tailored to your project.
+
+```bash
+gavel create config --provider=ollama \
+  "I want to analyze a Python Django app for security and code quality"
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `-o`, `--output` | Output file path | `.gavel/policies.yaml` |
+| `-p`, `--provider` | Preferred provider: `ollama`, `openrouter`, `anthropic`, `bedrock`, `openai` | auto-selected |
+
+If you don't specify a provider, the LLM picks one based on your requirements. The generated config includes 2-4 relevant starter policies.
+
+### `create wizard`
+
+Launches an interactive TUI for guided configuration generation. The wizard walks you through creating policies, rules, personas, or a full config with a menu-driven interface.
+
+```bash
+gavel create wizard
+```
+
+Navigation:
+- **Arrow keys** to select a menu item
+- **Enter** to confirm
+- **Esc** to go back
+- **Ctrl+C** or **q** to quit
+
+## Workflows
+
+### Bootstrap a new project
+
+```bash
+# Generate a tailored config
+gavel create config "Go REST API with JWT auth, PostgreSQL, and Docker" \
+  -o .gavel/policies.yaml
+
+# Review and adjust the generated config
+cat .gavel/policies.yaml
+
+# Run your first analysis
+gavel analyze --dir ./src
+```
+
+### Add a custom rule to an existing project
+
+```bash
+# Generate the rule
+gavel create rule --category=security \
+  "Detect use of md5 or sha1 for password hashing" \
+  -o .gavel/rules/custom.yaml
+
+# The rule is now active on the next analysis
+gavel analyze --dir ./src
+```
+
+### Create a team-specific persona
+
+```bash
+# Generate and review the persona
+gavel create persona "A frontend accessibility expert who checks for WCAG compliance"
+
+# Save it once you're happy with the output
+gavel create persona "A frontend accessibility expert who checks for WCAG compliance" \
+  -o .gavel/personas.yaml
+```
+
+## How It Works
+
+The `create` commands use BAML-defined generation functions that call an LLM (via OpenRouter) to produce structured output. The LLM receives your natural language description along with instructions about the expected output format (policy fields, rule conventions, persona structure, or full config layout). The structured response is then converted to YAML.
+
+Generation is separate from analysis — it uses the OpenRouter provider regardless of what provider your project is configured to use for `analyze`.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -26,6 +26,12 @@ provider:
     base_url: http://localhost:11434/v1
 ```
 
+Or generate one with AI — see [Generating Configuration](guides/generating-config.md):
+
+```bash
+gavel create config "Go REST API with security focus" -o .gavel/policies.yaml
+```
+
 ## 3. Analyze Your Code
 
 ```bash
@@ -59,4 +65,5 @@ The judge command evaluates findings against Rego policies and returns a verdict
 - **[Providers](PROVIDERS.md)** — Configure cloud providers for higher quality or faster analysis
 - **[Policies & Rules](configuration/policies.md)** — Customize what Gavel checks for
 - **[Personas](configuration/personas.md)** — Switch between code review, architecture, and security perspectives
+- **[Generating Configuration](guides/generating-config.md)** — Create policies, rules, and personas with AI
 - **[Gate PRs with CI](guides/ci-pr-gating.md)** — Automate analysis on every pull request

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -76,6 +76,55 @@ gavel judge --result 2026-02-18T15-30-31Z-e3980f
 }
 ```
 
+## `create`
+
+Generate configuration components from natural language descriptions using an LLM. Requires `OPENROUTER_API_KEY`.
+
+See the [Generating Configuration](guides/generating-config.md) guide for detailed usage and workflows.
+
+### Subcommands
+
+| Subcommand | Description |
+|------------|-------------|
+| `create policy [description]` | Generate a policy from a description |
+| `create rule [description]` | Generate a regex-based rule |
+| `create persona [description]` | Generate a custom analysis persona |
+| `create config [requirements]` | Generate a complete configuration |
+| `create wizard` | Launch interactive TUI wizard |
+
+### Examples
+
+```bash
+gavel create policy "Check that all public functions have doc comments"
+gavel create rule --category=security "Detect hardcoded JWT secrets"
+gavel create persona "A React hooks and performance expert"
+gavel create config --provider=ollama "Go microservices with security focus"
+gavel create wizard
+```
+
+### Flags
+
+**`create policy`**, **`create persona`**:
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `-o`, `--output` | Write to file instead of stdout | stdout |
+
+**`create rule`**:
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `-o`, `--output` | Write to file instead of stdout | stdout |
+| `-c`, `--category` | `security`, `reliability`, or `maintainability` | `maintainability` |
+| `-l`, `--languages` | Target languages (comma-separated) | `any` |
+
+**`create config`**:
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `-o`, `--output` | Output file path | `.gavel/policies.yaml` |
+| `-p`, `--provider` | Preferred provider | auto-selected |
+
 ## Global Flags
 
 | Flag | Description | Default |


### PR DESCRIPTION
## Summary
- Adds a new guide page (`docs/guides/generating-config.md`) documenting the `gavel create` command suite — `policy`, `rule`, `persona`, `config`, and `wizard` — for generating configuration from natural language using an LLM
- Updates CLI reference with `create` subcommand table, examples, and per-subcommand flags
- Adds links to the new guide from the sidebar, quickstart, and home page

## Test plan
- [ ] Verify docs site renders correctly with `docsify serve docs`
- [ ] Check all internal links resolve (sidebar, quickstart, README, CLI reference)
- [ ] Confirm CLI examples match actual `gavel create` command interface

🤖 Generated with [Claude Code](https://claude.com/claude-code)