### PR TITLE
docs: expand SARIF extensions table with all properties

### DIFF
--- a/docs/reference/sarif.md
+++ b/docs/reference/sarif.md
@@ -2,14 +2,45 @@
 
 Gavel produces standard [SARIF 2.1.0](https://sarifweb.azurewebsites.net/) output with additional properties under the `gavel/` namespace.
 
-## Extension Properties
+## Run-Level Properties
+
+These properties appear on each SARIF run (in `runs[0].properties`):
 
 | Property | Type | Description |
 |----------|------|-------------|
-| `gavel/confidence` | float (0.0–1.0) | LLM confidence in the finding |
-| `gavel/explanation` | string | Detailed reasoning behind the finding |
-| `gavel/recommendation` | string | Suggested fix or action |
 | `gavel/inputScope` | string | Input type: `files`, `diff`, or `directory` |
+| `gavel/persona` | string | Persona used for analysis (e.g., `code-reviewer`) |
+
+## Result-Level Properties
+
+These properties appear on each finding (in `results[].properties`):
+
+### Core properties (all findings)
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `gavel/confidence` | float (0.0-1.0) | Confidence in the finding |
+| `gavel/explanation` | string | Detailed reasoning behind the finding |
+| `gavel/tier` | string | Analysis tier: `instant`, `fast`, or `comprehensive` |
+
+### LLM findings (fast/comprehensive tier)
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `gavel/recommendation` | string | Suggested fix or action |
+| `gavel/cache_key` | string | Deterministic hash of analysis inputs (file content + policies + model + BAML templates) |
+| `gavel/analyzer` | object | Provider/model metadata (`provider`, `model`, `policies`) |
+
+### Instant-tier findings (regex and AST rules)
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `gavel/rule-source` | string | Rule origin: `CWE`, `OWASP`, `SonarQube`, or `Custom` |
+| `gavel/rule-type` | string | `ast` for tree-sitter checks (absent for regex) |
+| `gavel/cwe` | string[] | CWE references (e.g., `["CWE-798"]`) |
+| `gavel/owasp` | string[] | OWASP references (e.g., `["A07:2021"]`) |
+| `gavel/remediation` | string | Remediation guidance |
+| `gavel/references` | string[] | External reference URLs |
 
 ## Example Finding
 
@@ -29,15 +60,42 @@ Gavel produces standard [SARIF 2.1.0](https://sarifweb.azurewebsites.net/) outpu
   "properties": {
     "gavel/confidence": 0.9,
     "gavel/explanation": "The main function catches the error from Execute but discards it...",
-    "gavel/recommendation": "Log the error and exit with a non-zero status code"
+    "gavel/recommendation": "Log the error and exit with a non-zero status code",
+    "gavel/tier": "comprehensive",
+    "gavel/cache_key": "a1b2c3d4e5f6...",
+    "gavel/analyzer": {
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "policies": ["shall-be-merged"]
+    }
   }
 }
 ```
+
+## Suppressed Findings
+
+Suppressed findings include a standard SARIF `suppressions` array:
+
+```json
+{
+  "ruleId": "RGX003",
+  "suppressions": [{
+    "kind": "external",
+    "justification": "Acceptable in this project",
+    "properties": {
+      "gavel/source": "cli:user:alice",
+      "gavel/created": "2026-03-29T14:30:45Z"
+    }
+  }]
+}
+```
+
+See [Suppressing Findings](../guides/suppressions.md) for details.
 
 ## Compatibility
 
 SARIF output is compatible with:
 
-- **GitHub Code Scanning** — upload via the `github/codeql-action/upload-sarif` action
-- **VS Code SARIF Viewer** — view findings inline in the editor
-- **Any SARIF-compatible tool** — standard 2.1.0 format with extensions in `properties`
+- **GitHub Code Scanning** -- upload via the `github/codeql-action/upload-sarif` action
+- **VS Code SARIF Viewer** -- view findings inline in the editor
+- **Any SARIF-compatible tool** -- standard 2.1.0 format with extensions in `properties`


### PR DESCRIPTION
## Summary
- Expanded from 4 to 12+ documented SARIF extension properties
- Organized into run-level, core result, LLM-tier, and instant-tier sections
- Added suppressed findings example with suppression metadata
- Added cross-link to suppressions guide

## Test plan
- [ ] Verify properties match code in `internal/sarif/` and `internal/analyzer/tiered.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)