### PR TITLE
docs: add complete catalog of 19 built-in analysis rules

### DIFF
--- a/docs/configuration/policies.md
+++ b/docs/configuration/policies.md
@@ -56,6 +56,56 @@ policies:
 
 Gavel ships with 19 built-in analysis rules (15 regex + 4 AST) based on CWE, OWASP, and SonarQube standards. You can extend or override these with custom rule files.
 
+### Built-in Rules
+
+**Security** (6 rules):
+
+| ID | Name | Level | Languages | Description |
+|----|------|-------|-----------|-------------|
+| S2068 | hardcoded-credentials | error | all | Hard-coded passwords, API keys, tokens |
+| S3649 | sql-injection | error | all | SQL injection via string concatenation |
+| S2076 | command-injection | error | Go | OS command injection |
+| S2083 | path-traversal | warning | Go | File path traversal with user input |
+| S4426 | weak-crypto | warning | Go | Use of MD5, SHA1, DES, or RC4 |
+| S4830 | insecure-tls | error | Go | TLS certificate verification disabled |
+
+**Reliability** (4 rules):
+
+| ID | Name | Level | Languages | Description |
+|----|------|-------|-----------|-------------|
+| S1086 | error-ignored | warning | Go | Error return value assigned to `_` |
+| S1068 | empty-error-check | warning | Go | `if err != nil {}` with empty body |
+| S1144 | unreachable-code | warning | Go | Code after return/panic/os.Exit |
+| S2259 | defer-in-loop | warning | Go | Defer statement inside a loop |
+
+**Maintainability** (5 regex rules):
+
+| ID | Name | Level | Languages | Description |
+|----|------|-------|-----------|-------------|
+| S1135 | todo-fixme | note | all | TODO/FIXME/HACK/XXX comments |
+| S125 | commented-code | note | all | Commented-out code blocks |
+| S106 | debug-print | note | Go | fmt.Print/log.Print debug statements |
+| G601 | error-wrap-verb | note | Go | Use `%w` instead of `%s` to wrap errors |
+| S109 | magic-number | note | all | Large magic numbers in control flow |
+
+**Maintainability** (4 AST rules, tree-sitter):
+
+| ID | Name | Level | Languages | Default Config |
+|----|------|-------|-----------|----------------|
+| AST001 | function-length | note | Go, Python, JS/TS, Java, C, Rust | `max_lines: 50` |
+| AST002 | nesting-depth | warning | Go, Python, JS/TS, Java, C, Rust | `max_depth: 4` |
+| AST003 | empty-error-handler | warning | Go, Python, JS/TS, Java, C, Rust | — |
+| AST004 | param-count | note | Go, Python, JS/TS, Java, C, Rust | `max_params: 5` |
+
+All built-in rules run in the instant tier (no LLM call required). To disable a built-in rule, create a rule file with the same ID and set `enabled: false`:
+
+```yaml
+# .gavel/rules/overrides.yaml
+rules:
+  - id: "S1135"
+    enabled: false  # Disable TODO/FIXME detection
+```
+
 ### Rule Directories
 
 Rules are loaded and merged in order of precedence (highest wins, by rule ID):


### PR DESCRIPTION
## Summary
- Added tables listing all 19 built-in rules organized by category (security, reliability, maintainability)
- Each rule shows ID, name, level, language support, and description
- AST rules include default config values
- Added example of disabling a built-in rule via override file

## Test plan
- [ ] Verify rule IDs and names match `internal/rules/default_rules.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)