### PR TITLE
docs: fix broken example-configs.yaml links for Docsify

### DIFF
--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -323,7 +323,7 @@ The project-level config takes precedence over the machine-level config.
 
 ## See Also
 
-- `example-configs.yaml` - Complete configuration examples with all providers
+- [`example-configs.yaml`](https://github.com/chris-regnier/gavel/blob/main/example-configs.yaml) - Complete configuration examples with all providers
 - `CLAUDE.md` - Technical architecture and BAML details
 - Anthropic API docs: https://docs.anthropic.com/
 - OpenAI API docs: https://platform.openai.com/docs

--- a/docs/guides/ci-pr-gating.md
+++ b/docs/guides/ci-pr-gating.md
@@ -61,7 +61,7 @@ policies:
     enabled: true
 ```
 
-Commit this file to your repository. For other providers (Ollama, Bedrock, OpenAI), see [example-configs.yaml](../../example-configs.yaml).
+Commit this file to your repository. For other providers (Ollama, Bedrock, OpenAI), see [example-configs.yaml](https://github.com/chris-regnier/gavel/blob/main/example-configs.yaml).
 
 ## Step 3: Add the GitHub Actions Workflow
 

--- a/docs/guides/editor-integration.md
+++ b/docs/guides/editor-integration.md
@@ -54,7 +54,7 @@ policies:
     enabled: true
 ```
 
-If you prefer a cloud provider (Anthropic, OpenRouter, OpenAI, Bedrock), see [example-configs.yaml](../../example-configs.yaml) for complete configuration examples. Cloud providers require an API key set as an environment variable.
+If you prefer a cloud provider (Anthropic, OpenRouter, OpenAI, Bedrock), see [example-configs.yaml](https://github.com/chris-regnier/gavel/blob/main/example-configs.yaml) for complete configuration examples. Cloud providers require an API key set as an environment variable.
 
 ## Step 2: Run an Analysis
 


### PR DESCRIPTION
## Summary
- Replaced relative `../../example-configs.yaml` links with absolute GitHub URLs in PROVIDERS.md, editor-integration.md, and ci-pr-gating.md
- Relative paths going above `docs/` break in Docsify since only the `docs/` directory is served

## Test plan
- [ ] Verify links resolve correctly on the Docsify site
- [ ] Verify the GitHub URL points to the correct file

🤖 Generated with [Claude Code](https://claude.com/claude-code)