### PR TITLE
feat(sarif): populate help and helpUri on rule descriptors

### DIFF
--- a/cmd/gavel/analyze.go
+++ b/cmd/gavel/analyze.go
@@ -237,19 +237,22 @@ func runAnalyze(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("analyzing: %w", err)
 	}
 
-	rules := []sarif.ReportingDescriptor{}
+	descriptors := []sarif.ReportingDescriptor{}
 	for name, p := range cfg.Policies {
 		if p.Enabled {
-			rules = append(rules, sarif.ReportingDescriptor{
+			descriptors = append(descriptors, sarif.ReportingDescriptor{
 				ID:               name,
 				ShortDescription: sarif.Message{Text: p.Description},
 				DefaultConfig:    &sarif.ReportingConfiguration{Level: p.Severity},
 			})
 		}
 	}
+	for _, r := range loadedRules {
+		descriptors = append(descriptors, r.ToSARIFDescriptor())
+	}
 
 	// Assemble SARIF
-	sarifLog := sarif.Assemble(results, rules, inputScope, cfg.Persona)
+	sarifLog := sarif.Assemble(results, descriptors, inputScope, cfg.Persona)
 
 	// Calibration: apply threshold overrides
 	if thresholdOverrides != nil && len(sarifLog.Runs) > 0 {

--- a/internal/rules/sarif.go
+++ b/internal/rules/sarif.go
@@ -1,0 +1,103 @@
+package rules
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/chris-regnier/gavel/internal/sarif"
+)
+
+// ToSARIFDescriptor converts a Rule into a SARIF reportingDescriptor with
+// help text and helpUri populated from the rule's remediation, CWE, OWASP,
+// and reference metadata. This enables SARIF viewers (GitHub Code Scanning,
+// VS Code) to render rich, actionable rule documentation alongside findings.
+func (r Rule) ToSARIFDescriptor() sarif.ReportingDescriptor {
+	d := sarif.ReportingDescriptor{
+		ID:               r.ID,
+		Name:             r.Name,
+		ShortDescription: sarif.Message{Text: r.Message},
+	}
+
+	if r.Level != "" {
+		d.DefaultConfig = &sarif.ReportingConfiguration{Level: r.Level}
+	}
+
+	if r.Explanation != "" {
+		d.FullDescription = &sarif.Message{Text: r.Explanation}
+	}
+
+	if help := buildHelp(r); help != nil {
+		d.Help = help
+	}
+
+	d.HelpURI = resolveHelpURI(r)
+
+	return d
+}
+
+// buildHelp assembles a MultiformatMessage from remediation, CWE/OWASP,
+// and reference links. Returns nil when no help content is available.
+func buildHelp(r Rule) *sarif.MultiformatMessage {
+	if r.Remediation == "" && len(r.CWE) == 0 && len(r.OWASP) == 0 && len(r.References) == 0 {
+		return nil
+	}
+
+	var textParts []string
+	var mdParts []string
+
+	if r.Remediation != "" {
+		textParts = append(textParts, r.Remediation)
+		mdParts = append(mdParts, "**Remediation:** "+r.Remediation)
+	}
+
+	if len(r.CWE) > 0 {
+		var cweLinks []string
+		for _, id := range r.CWE {
+			cweLinks = append(cweLinks, fmt.Sprintf("[%s](%s)", id, cweURL(id)))
+		}
+		textParts = append(textParts, "CWE: "+strings.Join(r.CWE, ", "))
+		mdParts = append(mdParts, "**CWE:** "+strings.Join(cweLinks, ", "))
+	}
+
+	if len(r.OWASP) > 0 {
+		joined := strings.Join(r.OWASP, ", ")
+		textParts = append(textParts, "OWASP: "+joined)
+		mdParts = append(mdParts, "**OWASP:** "+joined)
+	}
+
+	if len(r.References) > 0 {
+		textLines := []string{"References:"}
+		mdLines := []string{"**References:**"}
+		for _, ref := range r.References {
+			textLines = append(textLines, "- "+ref)
+			mdLines = append(mdLines, "- "+ref)
+		}
+		textParts = append(textParts, strings.Join(textLines, "\n"))
+		mdParts = append(mdParts, strings.Join(mdLines, "\n"))
+	}
+
+	return &sarif.MultiformatMessage{
+		Text:     strings.Join(textParts, "\n\n"),
+		Markdown: strings.Join(mdParts, "\n\n"),
+	}
+}
+
+// resolveHelpURI picks a canonical documentation URL for the rule. It prefers
+// the first entry in References (typically the CWE or OWASP page), then
+// synthesizes a cwe.mitre.org URL if a CWE id is present, and otherwise
+// returns an empty string.
+func resolveHelpURI(r Rule) string {
+	if len(r.References) > 0 {
+		return r.References[0]
+	}
+	if len(r.CWE) > 0 {
+		return cweURL(r.CWE[0])
+	}
+	return ""
+}
+
+// cweURL returns the canonical cwe.mitre.org URL for a CWE id like "CWE-798".
+func cweURL(id string) string {
+	num := strings.TrimPrefix(id, "CWE-")
+	return "https://cwe.mitre.org/data/definitions/" + num + ".html"
+}

--- a/internal/rules/sarif_test.go
+++ b/internal/rules/sarif_test.go
@@ -1,0 +1,151 @@
+package rules
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestToSARIFDescriptor_AllFields(t *testing.T) {
+	r := Rule{
+		ID:          "S2068",
+		Name:        "hardcoded-credentials",
+		Category:    CategorySecurity,
+		Level:       "error",
+		Confidence:  0.85,
+		Message:     "Hard-coded credentials detected",
+		Explanation: "Credentials should not be hard-coded in source code.",
+		Remediation: "Store credentials in environment variables or a secrets manager.",
+		Source:      SourceCWE,
+		CWE:         []string{"CWE-259", "CWE-798"},
+		OWASP:       []string{"A07:2021"},
+		References: []string{
+			"https://cwe.mitre.org/data/definitions/798.html",
+			"https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures/",
+		},
+	}
+
+	d := r.ToSARIFDescriptor()
+
+	if d.ID != "S2068" {
+		t.Errorf("ID: expected S2068, got %q", d.ID)
+	}
+	if d.Name != "hardcoded-credentials" {
+		t.Errorf("Name: expected hardcoded-credentials, got %q", d.Name)
+	}
+	if d.ShortDescription.Text != "Hard-coded credentials detected" {
+		t.Errorf("ShortDescription: got %q", d.ShortDescription.Text)
+	}
+	if d.FullDescription == nil || !strings.Contains(d.FullDescription.Text, "Credentials should not be hard-coded") {
+		t.Errorf("FullDescription: expected explanation, got %+v", d.FullDescription)
+	}
+	if d.DefaultConfig == nil || d.DefaultConfig.Level != "error" {
+		t.Errorf("DefaultConfig: expected level=error, got %+v", d.DefaultConfig)
+	}
+
+	if d.Help == nil {
+		t.Fatal("Help: expected populated, got nil")
+	}
+	if !strings.Contains(d.Help.Text, "environment variables") {
+		t.Errorf("Help.Text: expected remediation text, got %q", d.Help.Text)
+	}
+	if !strings.Contains(d.Help.Markdown, "**Remediation:**") {
+		t.Errorf("Help.Markdown: expected remediation heading, got %q", d.Help.Markdown)
+	}
+	if !strings.Contains(d.Help.Markdown, "CWE-798") {
+		t.Errorf("Help.Markdown: expected CWE-798 reference, got %q", d.Help.Markdown)
+	}
+	if !strings.Contains(d.Help.Markdown, "https://cwe.mitre.org/data/definitions/798.html") {
+		t.Errorf("Help.Markdown: expected reference URL, got %q", d.Help.Markdown)
+	}
+	if !strings.Contains(d.Help.Markdown, "A07:2021") {
+		t.Errorf("Help.Markdown: expected OWASP entry, got %q", d.Help.Markdown)
+	}
+	// Reference list items must not be separated by blank lines - that would
+	// render each item as a separate paragraph in markdown viewers.
+	refList := "**References:**\n- https://cwe.mitre.org/data/definitions/798.html\n- https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures/"
+	if !strings.Contains(d.Help.Markdown, refList) {
+		t.Errorf("Help.Markdown: expected contiguous reference list, got %q", d.Help.Markdown)
+	}
+
+	// HelpURI should fall back to the first reference URL when not explicitly set.
+	if d.HelpURI != "https://cwe.mitre.org/data/definitions/798.html" {
+		t.Errorf("HelpURI: expected first reference URL, got %q", d.HelpURI)
+	}
+}
+
+func TestToSARIFDescriptor_Minimal(t *testing.T) {
+	r := Rule{
+		ID:         "R001",
+		Level:      "warning",
+		Confidence: 0.5,
+		Message:    "found foo",
+	}
+
+	d := r.ToSARIFDescriptor()
+
+	if d.ID != "R001" {
+		t.Errorf("ID: expected R001, got %q", d.ID)
+	}
+	if d.ShortDescription.Text != "found foo" {
+		t.Errorf("ShortDescription: got %q", d.ShortDescription.Text)
+	}
+	if d.DefaultConfig == nil || d.DefaultConfig.Level != "warning" {
+		t.Errorf("DefaultConfig: expected level=warning, got %+v", d.DefaultConfig)
+	}
+	// With no remediation/CWE/references/explanation, help should be nil.
+	if d.Help != nil {
+		t.Errorf("Help: expected nil for minimal rule, got %+v", d.Help)
+	}
+	if d.FullDescription != nil {
+		t.Errorf("FullDescription: expected nil for minimal rule, got %+v", d.FullDescription)
+	}
+	if d.HelpURI != "" {
+		t.Errorf("HelpURI: expected empty, got %q", d.HelpURI)
+	}
+}
+
+func TestToSARIFDescriptor_RemediationOnly(t *testing.T) {
+	r := Rule{
+		ID:          "R002",
+		Level:       "warning",
+		Confidence:  0.5,
+		Message:     "issue",
+		Remediation: "Do the right thing.",
+	}
+
+	d := r.ToSARIFDescriptor()
+
+	if d.Help == nil {
+		t.Fatal("Help: expected populated, got nil")
+	}
+	if !strings.Contains(d.Help.Text, "Do the right thing.") {
+		t.Errorf("Help.Text: got %q", d.Help.Text)
+	}
+	// No references, so HelpURI stays empty.
+	if d.HelpURI != "" {
+		t.Errorf("HelpURI: expected empty, got %q", d.HelpURI)
+	}
+}
+
+func TestToSARIFDescriptor_CWEWithoutReferences(t *testing.T) {
+	r := Rule{
+		ID:         "R003",
+		Level:      "error",
+		Confidence: 0.9,
+		Message:    "cwe only",
+		CWE:        []string{"CWE-89"},
+	}
+
+	d := r.ToSARIFDescriptor()
+
+	if d.Help == nil {
+		t.Fatal("Help: expected populated, got nil")
+	}
+	if !strings.Contains(d.Help.Markdown, "CWE-89") {
+		t.Errorf("Help.Markdown: expected CWE-89, got %q", d.Help.Markdown)
+	}
+	// HelpURI should fall back to the synthesized cwe.mitre.org URL.
+	if d.HelpURI != "https://cwe.mitre.org/data/definitions/89.html" {
+		t.Errorf("HelpURI: expected synthesized CWE URL, got %q", d.HelpURI)
+	}
+}

--- a/internal/sarif/sarif.go
+++ b/internal/sarif/sarif.go
@@ -34,12 +34,24 @@ type Driver struct {
 
 type ReportingDescriptor struct {
 	ID               string                  `json:"id"`
+	Name             string                  `json:"name,omitempty"`
 	ShortDescription Message                 `json:"shortDescription,omitempty"`
+	FullDescription  *Message                `json:"fullDescription,omitempty"`
+	Help             *MultiformatMessage     `json:"help,omitempty"`
+	HelpURI          string                  `json:"helpUri,omitempty"`
 	DefaultConfig    *ReportingConfiguration `json:"defaultConfiguration,omitempty"`
 }
 
 type ReportingConfiguration struct {
 	Level string `json:"level,omitempty"`
+}
+
+// MultiformatMessage carries a message in both plain text and markdown forms,
+// per SARIF 2.1.0 §3.11 (multiformatMessageString). SARIF viewers such as
+// GitHub Code Scanning and VS Code render the markdown form as rule help.
+type MultiformatMessage struct {
+	Text     string `json:"text,omitempty"`
+	Markdown string `json:"markdown,omitempty"`
 }
 
 type Result struct {

--- a/internal/sarif/sarif_test.go
+++ b/internal/sarif/sarif_test.go
@@ -48,3 +48,65 @@ func TestSarifLog_MarshalJSON(t *testing.T) {
 		t.Errorf("expected recommendation preserved")
 	}
 }
+
+func TestReportingDescriptor_HelpMarshaling(t *testing.T) {
+	log := NewLog("gavel", "0.1.0")
+	log.Runs[0].Tool.Driver.Rules = []ReportingDescriptor{{
+		ID:               "S2068",
+		Name:             "hardcoded-credentials",
+		ShortDescription: Message{Text: "Hard-coded credentials detected"},
+		FullDescription:  &Message{Text: "Credentials should not be hard-coded."},
+		Help: &MultiformatMessage{
+			Text:     "Use environment variables.\n\nCWE: CWE-798",
+			Markdown: "**Remediation:** Use environment variables.\n\n**CWE:** [CWE-798](https://cwe.mitre.org/data/definitions/798.html)",
+		},
+		HelpURI:       "https://cwe.mitre.org/data/definitions/798.html",
+		DefaultConfig: &ReportingConfiguration{Level: "error"},
+	}}
+
+	data, err := json.Marshal(log)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Confirm the SARIF standard field names appear in the serialized form.
+	for _, want := range []string{
+		`"name":"hardcoded-credentials"`,
+		`"fullDescription"`,
+		`"help"`,
+		`"markdown"`,
+		`"helpUri":"https://cwe.mitre.org/data/definitions/798.html"`,
+	} {
+		if !contains(string(data), want) {
+			t.Errorf("expected JSON to contain %s, got: %s", want, data)
+		}
+	}
+
+	// Round-trip through JSON and verify fields land back on the struct.
+	var parsed Log
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatal(err)
+	}
+	if len(parsed.Runs[0].Tool.Driver.Rules) != 1 {
+		t.Fatalf("expected 1 rule, got %d", len(parsed.Runs[0].Tool.Driver.Rules))
+	}
+	rd := parsed.Runs[0].Tool.Driver.Rules[0]
+	if rd.Name != "hardcoded-credentials" {
+		t.Errorf("Name: got %q", rd.Name)
+	}
+	if rd.Help == nil || rd.Help.Markdown == "" {
+		t.Errorf("Help.Markdown: expected populated, got %+v", rd.Help)
+	}
+	if rd.HelpURI != "https://cwe.mitre.org/data/definitions/798.html" {
+		t.Errorf("HelpURI: got %q", rd.HelpURI)
+	}
+}
+
+func contains(s, substr string) bool {
+	for i := 0; i+len(substr) <= len(s); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/service/analyze.go
+++ b/internal/service/analyze.go
@@ -8,6 +8,7 @@ import (
 	"github.com/chris-regnier/gavel/internal/analyzer"
 	"github.com/chris-regnier/gavel/internal/config"
 	"github.com/chris-regnier/gavel/internal/input"
+	"github.com/chris-regnier/gavel/internal/rules"
 	"github.com/chris-regnier/gavel/internal/sarif"
 	"github.com/chris-regnier/gavel/internal/store"
 )
@@ -57,7 +58,7 @@ func (s *AnalyzeService) Analyze(ctx context.Context, req AnalyzeRequest) (*Anal
 		return nil, fmt.Errorf("analyzing: %w", err)
 	}
 
-	sarifLog := sarif.Assemble(results, policyRules(req.Config.Policies), scopeFromArtifacts(req.Artifacts), req.Config.Persona)
+	sarifLog := sarif.Assemble(results, buildDescriptors(req.Config.Policies, req.Rules), scopeFromArtifacts(req.Artifacts), req.Config.Persona)
 
 	resultID, err := s.store.WriteSARIF(ctx, sarifLog)
 	if err != nil {
@@ -148,7 +149,7 @@ func (s *AnalyzeService) AnalyzeStream(ctx context.Context, req AnalyzeRequest) 
 		}
 
 		// Store final SARIF
-		sarifLog := sarif.Assemble(allResults, policyRules(req.Config.Policies), scopeFromArtifacts(req.Artifacts), req.Config.Persona)
+		sarifLog := sarif.Assemble(allResults, buildDescriptors(req.Config.Policies, req.Rules), scopeFromArtifacts(req.Artifacts), req.Config.Persona)
 		resultID, err := s.store.WriteSARIF(ctx, sarifLog)
 		if err != nil {
 			errCh <- fmt.Errorf("storing SARIF: %w", err)
@@ -164,19 +165,24 @@ func (s *AnalyzeService) AnalyzeStream(ctx context.Context, req AnalyzeRequest) 
 	return tierCh, resultCh, errCh
 }
 
-// policyRules converts enabled policies to SARIF reporting descriptors.
-func policyRules(policies map[string]config.Policy) []sarif.ReportingDescriptor {
-	var rules []sarif.ReportingDescriptor
+// buildDescriptors assembles SARIF reportingDescriptors from both enabled
+// policies and loaded rules. Rule descriptors carry help/helpUri populated
+// from the rule's remediation, CWE, and reference metadata.
+func buildDescriptors(policies map[string]config.Policy, loadedRules []rules.Rule) []sarif.ReportingDescriptor {
+	var descriptors []sarif.ReportingDescriptor
 	for name, p := range policies {
 		if p.Enabled {
-			rules = append(rules, sarif.ReportingDescriptor{
+			descriptors = append(descriptors, sarif.ReportingDescriptor{
 				ID:               name,
 				ShortDescription: sarif.Message{Text: p.Description},
 				DefaultConfig:    &sarif.ReportingConfiguration{Level: p.Severity},
 			})
 		}
 	}
-	return rules
+	for _, r := range loadedRules {
+		descriptors = append(descriptors, r.ToSARIFDescriptor())
+	}
+	return descriptors
 }
 
 // scopeFromArtifacts determines the input scope string from artifact kinds.


### PR DESCRIPTION
## Summary
- Map `remediation`, `cwe`, `owasp`, and `references` from `rules.Rule` into SARIF `reportingDescriptor.help` (both `text` and `markdown`) and `helpUri`, so GitHub Code Scanning, VS Code, and other viewers render rich, actionable rule documentation (closes #76).
- Add `Rule.ToSARIFDescriptor()` and thread rule descriptors through the `cmd/gavel/analyze.go` and `internal/service/analyze.go` SARIF assembly paths alongside policy descriptors. The MCP server currently runs only the LLM tier (no pattern rules), so it is out of scope.
- Extend `sarif.ReportingDescriptor` with `Name`, `FullDescription`, `Help`, and `HelpURI`, plus a new `MultiformatMessage` type (SARIF 2.1.0 §3.11).

## Example output
For the embedded `S2068` rule, the SARIF driver now emits:

```json
{
  "id": "S2068",
  "name": "hardcoded-credentials",
  "shortDescription": { "text": "Hard-coded credentials detected" },
  "fullDescription": { "text": "Credentials should not be hard-coded in source code..." },
  "help": {
    "text": "Store credentials in environment variables...\n\nCWE: CWE-259, CWE-798\n\nOWASP: A07:2021\n\nReferences:\n- https://cwe.mitre.org/data/definitions/798.html\n- https://owasp.org/...",
    "markdown": "**Remediation:** Store credentials...\n\n**CWE:** [CWE-259](https://cwe.mitre.org/data/definitions/259.html), [CWE-798](https://cwe.mitre.org/data/definitions/798.html)\n\n**OWASP:** A07:2021\n\n**References:**\n- https://cwe.mitre.org/data/definitions/798.html\n- ..."
  },
  "helpUri": "https://cwe.mitre.org/data/definitions/798.html",
  "defaultConfiguration": { "level": "error" }
}
```

`helpUri` prefers the first entry in `references`, falls back to a synthesized `cwe.mitre.org` URL, and is omitted when neither is present.

## Test plan
- [x] `go test ./...` — all packages pass
- [x] `go vet ./...` — clean
- [x] New `TestToSARIFDescriptor_*` covers full, minimal, remediation-only, and CWE-without-references cases, including the contiguous markdown reference list
- [x] New `TestReportingDescriptor_HelpMarshaling` verifies JSON serialization of the new SARIF fields round-trips cleanly
- [x] Smoke test: ran `dist/gavel analyze` against a file containing a hardcoded secret and inspected the stored SARIF; S2068 descriptor includes populated `help.text`, `help.markdown`, and `helpUri`

🤖 Generated with [Claude Code](https://claude.com/claude-code)