### PR TITLE
fix(lsp): portable dup2 helper in cmd/gavel for linux/arm64

### DIFF
--- a/cmd/gavel/dup2_darwin.go
+++ b/cmd/gavel/dup2_darwin.go
@@ -1,0 +1,11 @@
+//go:build darwin
+
+package main
+
+import "syscall"
+
+// dup2 duplicates oldfd onto newfd with POSIX dup2 semantics.
+// Darwin's syscall package exposes Dup2 directly on both amd64 and arm64.
+func dup2(oldfd, newfd int) error {
+	return syscall.Dup2(oldfd, newfd)
+}

--- a/cmd/gavel/dup2_linux.go
+++ b/cmd/gavel/dup2_linux.go
@@ -1,0 +1,12 @@
+//go:build linux
+
+package main
+
+import "golang.org/x/sys/unix"
+
+// dup2 duplicates oldfd onto newfd with POSIX dup2 semantics.
+// syscall.Dup2 is not exposed on linux/arm64 (the kernel only implements
+// dup3 there), so this uses unix.Dup3 which is available on every linux arch.
+func dup2(oldfd, newfd int) error {
+	return unix.Dup3(oldfd, newfd, 0)
+}

--- a/cmd/gavel/lsp.go
+++ b/cmd/gavel/lsp.go
@@ -144,7 +144,7 @@ func runLSP(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("duplicating stdout: %w", err)
 	}
-	if err := syscall.Dup2(2, 1); err != nil {
+	if err := dup2(2, 1); err != nil {
 		return fmt.Errorf("redirecting stdout to stderr: %w", err)
 	}
 	lspOut := os.NewFile(uintptr(lspFD), "lsp-stdout")


### PR DESCRIPTION
## Summary
CI's new `task check:cross` caught a second `syscall.Dup2` linux/arm64 issue in `cmd/gavel/lsp.go:147` — the LSP subcommand uses the same stdout-redirect trick as the analyzer and hit the same missing-on-arm64 primitive.

Apply the same fix pattern: package-local `dup2` helper split by OS (`unix.Dup3` on Linux, `syscall.Dup2` on Darwin).

This is a follow-up to #85 which landed the analyzer fix and the CI cross-compile check that detected this.

## Test plan
- [x] `task check:cross` passes locally on macOS
- [ ] CI `test (ubuntu-latest)` green (proves linux/arm64 cross-compile)
- [ ] CI `test (macos-latest)` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)