### PR TITLE
feat(sarif): use standard taxonomies for CWE/OWASP references

### DIFF
--- a/docs/reference/sarif.md
+++ b/docs/reference/sarif.md
@@ -11,6 +11,36 @@ These properties appear on each SARIF run (in `runs[0].properties`):
 | `gavel/inputScope` | string | Input type: `files`, `diff`, or `directory` |
 | `gavel/persona` | string | Persona used for analysis (e.g., `code-reviewer`) |
 
+## Taxonomies
+
+Rules that reference CWE or OWASP categories emit standard SARIF taxonomies in `runs[0].taxonomies` and `reportingDescriptor.relationships`. This enables interoperability with GitHub Advanced Security, Semgrep, Snyk, DefectDojo, and other SARIF-aware security dashboards.
+
+```json
+{
+  "taxonomies": [{
+    "name": "CWE",
+    "organization": "MITRE",
+    "taxa": [
+      { "id": "798" },
+      { "id": "89" }
+    ]
+  }],
+  "tool": {
+    "driver": {
+      "rules": [{
+        "id": "S2068",
+        "relationships": [{
+          "target": { "id": "798", "toolComponent": { "name": "CWE" } },
+          "kinds": ["relevant"]
+        }]
+      }]
+    }
+  }
+}
+```
+
+Taxonomies are built automatically from the `cwe` and `owasp` fields in rule definitions. No additional configuration is needed.
+
 ## Result-Level Properties
 
 These properties appear on each finding (in `results[].properties`):
@@ -37,8 +67,6 @@ These properties appear on each finding (in `results[].properties`):
 |----------|------|-------------|
 | `gavel/rule-source` | string | Rule origin: `CWE`, `OWASP`, `SonarQube`, or `Custom` |
 | `gavel/rule-type` | string | `ast` for tree-sitter checks (absent for regex) |
-| `gavel/cwe` | string[] | CWE references (e.g., `["CWE-798"]`) |
-| `gavel/owasp` | string[] | OWASP references (e.g., `["A07:2021"]`) |
 | `gavel/remediation` | string | Remediation guidance |
 | `gavel/references` | string[] | External reference URLs |
 

--- a/docs/superpowers/specs/2026-04-09-sarif-taxonomies-design.md
+++ b/docs/superpowers/specs/2026-04-09-sarif-taxonomies-design.md
@@ -1,0 +1,282 @@
+# SARIF Taxonomies for CWE/OWASP References
+
+**Issue:** [#77](https://github.com/chris-regnier/gavel/issues/77)
+**Date:** 2026-04-09
+**Status:** Design
+
+## Summary
+
+Replace the custom `gavel/cwe` and `gavel/owasp` result properties with the
+SARIF 2.1.0-standard `run.taxonomies` array plus
+`reportingDescriptor.relationships`. This makes Gavel's CWE/OWASP references
+interoperable with security dashboards (GitHub Advanced Security, Semgrep,
+Snyk, DefectDojo) that natively consume SARIF taxonomies.
+
+## Motivation
+
+CWE and OWASP references currently live in two places:
+
+1. **Result properties** (`gavel/cwe`, `gavel/owasp`) — set in
+   `internal/analyzer/tiered.go` for regex and AST rule findings.
+2. **Rule help text** — rendered as `**CWE:** ...` / `**OWASP:** ...` sections
+   inside the `ReportingDescriptor.Help.Markdown` field by
+   `internal/rules/sarif.go#buildHelp`.
+
+Neither is portable. Consumers that understand SARIF's native taxonomy format
+cannot discover Gavel's references without custom parsers. Moving to the
+standard format unlocks existing tooling for free.
+
+## Non-Goals
+
+- No changes to Rego policies, verdicts, or evaluation.
+- No changes to the `Rule` YAML schema (the `cwe` / `owasp` fields stay).
+- No populating CWE/OWASP on LLM-driven findings (the BAML `Finding` struct
+  currently has no CWE/OWASP fields — out of scope).
+- No canonical CWE/OWASP name lookup. Emitted taxa carry `id` only.
+
+## Design
+
+### Dependency Direction
+
+Current layering is `rules → sarif` (the rules package imports sarif types,
+not the reverse). The design preserves that. New taxonomy logic sits either
+in `sarif` (as pure functions over descriptors) or in `rules` (as conversion
+logic on `Rule`). Nothing in `sarif` learns about the `rules` package.
+
+### 1. New SARIF types (`internal/sarif/sarif.go`)
+
+Add these types to model SARIF §3.19 (`toolComponent`), §3.19.6 (`taxon`),
+§3.52 (`reportingDescriptorRelationship`), and §3.53
+(`reportingDescriptorReference`):
+
+```go
+// ToolComponent represents a SARIF toolComponent (§3.19). Used inside
+// Run.Taxonomies to describe a taxonomy (e.g., CWE, OWASP) and its taxa.
+type ToolComponent struct {
+    Name         string  `json:"name"`
+    Organization string  `json:"organization,omitempty"`
+    Taxa         []Taxon `json:"taxa,omitempty"`
+}
+
+// Taxon represents an entry in a taxonomy (a reportingDescriptor used as
+// a taxon, §3.19.6).
+type Taxon struct {
+    ID   string `json:"id"`
+    Name string `json:"name,omitempty"`
+}
+
+// Relationship represents a reportingDescriptorRelationship (§3.52) attached
+// to a rule, pointing at a taxon in a taxonomy.
+type Relationship struct {
+    Target RelationshipTarget `json:"target"`
+    Kinds  []string           `json:"kinds,omitempty"`
+}
+
+// RelationshipTarget represents a reportingDescriptorReference (§3.53)
+// identifying a specific taxon within a named toolComponent.
+type RelationshipTarget struct {
+    ID            string                  `json:"id"`
+    ToolComponent *ToolComponentReference `json:"toolComponent,omitempty"`
+}
+
+// ToolComponentReference identifies a toolComponent by name. Used by
+// RelationshipTarget to point at a taxonomy.
+type ToolComponentReference struct {
+    Name string `json:"name"`
+}
+```
+
+Extend existing types:
+
+- `ReportingDescriptor` gains `Relationships []Relationship` with
+  `json:"relationships,omitempty"`.
+- `Run` gains `Taxonomies []ToolComponent` with `json:"taxonomies,omitempty"`.
+
+`omitempty` on every optional field preserves the current JSON shape for
+outputs that have no taxonomies (e.g., LLM-only runs with no rule hits).
+
+### 2. Rule → Relationships conversion (`internal/rules/sarif.go`)
+
+Extend `Rule.ToSARIFDescriptor()` to populate `d.Relationships` from
+`r.CWE` and `r.OWASP`:
+
+```go
+for _, cwe := range r.CWE {
+    id := strings.TrimPrefix(cwe, "CWE-")  // "CWE-798" → "798"
+    d.Relationships = append(d.Relationships, sarif.Relationship{
+        Target: sarif.RelationshipTarget{
+            ID:            id,
+            ToolComponent: &sarif.ToolComponentReference{Name: "CWE"},
+        },
+        Kinds: []string{"relevant"},
+    })
+}
+for _, owasp := range r.OWASP {
+    d.Relationships = append(d.Relationships, sarif.Relationship{
+        Target: sarif.RelationshipTarget{
+            ID:            owasp,  // e.g., "A07:2021"
+            ToolComponent: &sarif.ToolComponentReference{Name: "OWASP"},
+        },
+        Kinds: []string{"relevant"},
+    })
+}
+```
+
+Decisions embedded here:
+
+- **Kind:** `"relevant"` for all relationships. Most generic SARIF value and
+  matches how Semgrep / GitHub Code Scanning emit CWE references. Avoids
+  claiming stricter semantics like `superset` / `subset`.
+- **CWE ID format:** Strip the `CWE-` prefix so the taxon `id` is the bare
+  number (`"798"`). This matches the issue example and the MITRE taxonomy's
+  native identifier scheme.
+- **OWASP ID format:** Keep as-is (`"A07:2021"`). OWASP Top 10 categories are
+  already referenced by that exact string.
+
+Additionally, **remove** the CWE/OWASP synthesis from `buildHelp()` (the
+`**CWE:** ...` and `**OWASP:** ...` markdown lines). That information is now
+first-class on the descriptor via `relationships`. The `buildHelp` guard
+`if r.Remediation == "" && len(r.CWE) == 0 && ... { return nil }` becomes
+`if r.Remediation == "" && len(r.References) == 0 { return nil }`.
+
+**Keep** `resolveHelpURI()` and its `cweURL()` fallback untouched: `helpUri`
+points at primary rule documentation, which is a different concept than
+taxonomy relationships, and the fallback is still useful when a rule has
+no explicit `references` list.
+
+### 3. Taxonomy aggregation (`internal/sarif/taxonomies.go`, new)
+
+A pure function over rule descriptors:
+
+```go
+// BuildTaxonomies walks the Relationships of each rule and returns the
+// unique set of SARIF toolComponents referenced, each populated with its
+// taxa. Taxa and taxonomies are sorted deterministically so that output
+// is stable across runs. Returns nil when no relationships are present.
+func BuildTaxonomies(rules []ReportingDescriptor) []ToolComponent
+```
+
+Implementation sketch:
+
+1. Group relationship targets by `toolComponent.name`.
+2. Within each group, dedupe by `target.id` using a `map[string]struct{}`.
+3. Sort taxon IDs lexicographically for stability.
+4. Emit one `ToolComponent` per group, setting `Organization`:
+   - `"CWE"` → `"MITRE"`
+   - `"OWASP"` → `"OWASP Foundation"`
+   - anything else → left empty
+5. Sort the returned slice by `ToolComponent.Name` so ordering is stable.
+
+Deterministic ordering matters because SARIF output is consumed by cache
+keying and snapshot tests. A map-iteration-order-based output would cause
+spurious diffs.
+
+### 4. Assembler wiring
+
+**`internal/sarif/builder.go`** — in `Assembler.Build()`, right after
+`log.Runs[0].Tool.Driver.Rules = a.rules`:
+
+```go
+if taxa := BuildTaxonomies(a.rules); len(taxa) > 0 {
+    log.Runs[0].Taxonomies = taxa
+}
+```
+
+**`internal/sarif/assembler.go`** — same addition in the legacy `Assemble()`
+function for parity. The `service.analyze` pipeline calls `Assemble()`, not
+`Assembler.Build()`, so this is the code path actually exercised in
+production today.
+
+### 5. Remove `gavel/cwe` / `gavel/owasp` result properties
+
+Delete these blocks from `internal/analyzer/tiered.go`:
+
+- Lines 375–380 (regex rule path, inside `runPatternMatching`)
+- Lines 464–469 (AST rule path, inside `runASTRules`)
+
+Update test fixture `internal/output/sarif_test.go:38` to remove the
+`"gavel/cwe": []string{"CWE-798"}` entry.
+
+### 6. Test plan
+
+Tests written before or alongside implementation (TDD):
+
+- **`internal/sarif/taxonomies_test.go`** (new): table-driven tests for
+  `BuildTaxonomies`:
+  - Empty rules → `nil` return.
+  - Single rule with one CWE → one CWE taxonomy, one taxon.
+  - Single rule with two CWEs → one CWE taxonomy, two taxa.
+  - Two rules referencing the same CWE → deduped.
+  - Mixed CWE + OWASP → two taxonomies.
+  - Unknown taxonomy name → organization field empty.
+  - Stable ordering: shuffle input, assert sorted output.
+- **`internal/sarif/sarif_test.go`** (extend): JSON serialization check
+  for `Taxon`, `ToolComponent`, `Relationship`, `RelationshipTarget`, and
+  `ToolComponentReference` — verify `omitempty` drops unset fields.
+- **`internal/rules/sarif_test.go`** (extend):
+  - `ToSARIFDescriptor` for a rule with CWE + OWASP populates
+    `Relationships` in the expected shape (CWE ID stripped, OWASP kept).
+  - `buildHelp` no longer contains `**CWE:**` / `**OWASP:**` markdown lines
+    (but still contains `**Remediation:**` and `**References:**`).
+  - `resolveHelpURI` still returns `cwe.mitre.org/definitions/798.html`
+    when no `references` list is present.
+  - A rule with no remediation, no CWE, no OWASP, and no references still
+    produces a nil `Help`.
+- **`internal/sarif/assembler_test.go`** (extend): after `Assemble()`,
+  assert `Runs[0].Taxonomies` is populated when rule descriptors carry
+  relationships.
+- **`internal/analyzer/tiered_test.go`**: remove any assertions on
+  `gavel/cwe` / `gavel/owasp` result properties and add a negative
+  assertion that they are absent.
+
+Run the integration test (`go test -run TestIntegration ./...`) to
+confirm end-to-end SARIF output still parses and validates.
+
+### 7. Documentation
+
+Update `docs/reference/sarif.md`:
+
+- Add a "Taxonomies" section describing the new `run.taxonomies` array
+  and the rule `relationships` field, with a trimmed JSON example.
+- Remove the `gavel/cwe` and `gavel/owasp` entries from the result
+  properties table.
+
+## Out of Scope
+
+- **LLM findings with CWE/OWASP.** The BAML `Finding` struct has no
+  CWE/OWASP fields today, so LLM-driven results carry no taxonomy refs.
+  Adding them would require a BAML schema change (`Finding.cwe` /
+  `Finding.owasp`) plus type-builder regeneration — separate issue.
+- **Taxon canonical names.** Our rule YAML stores only IDs. Populating
+  `Taxon.Name` would require a lookup map; users picked "omit name" as
+  the simplest correct option.
+- **`isComprehensive` and `version` on CWE/OWASP taxonomies.** We are
+  only emitting the subset our rules reference, not the complete CWE or
+  OWASP catalog, so these fields are intentionally omitted.
+
+## Risks & Mitigations
+
+- **SARIF validator regressions.** Adding new fields at `run.taxonomies`
+  could change JSON shape for snapshot tests. Mitigation: audit existing
+  golden files in `internal/sarif/*_test.go` and
+  `internal/output/sarif_test.go` — update only where taxonomies are
+  actually expected.
+- **Cache-key drift.** `cache_key` is computed from file content + model
+  + policies + BAML templates (`internal/sarif/builder.go`), not from
+  the SARIF log itself. Adding taxonomies to the output does NOT change
+  the cache key — existing cached SARIF stays valid.
+- **Ordering instability causing spurious diffs.** Mitigated by
+  deterministic sorting in `BuildTaxonomies`.
+
+## Implementation Order
+
+1. Add the new SARIF types + extend `ReportingDescriptor` / `Run`.
+2. Write `taxonomies_test.go`.
+3. Implement `BuildTaxonomies`.
+4. Extend `Rule.ToSARIFDescriptor` and its tests.
+5. Strip CWE/OWASP from `buildHelp` and update tests.
+6. Wire `BuildTaxonomies` into `Assemble` and `Assembler.Build`.
+7. Remove `gavel/cwe` / `gavel/owasp` props from `tiered.go` and update
+   fixtures.
+8. Update `docs/reference/sarif.md`.
+9. `task lint && task test && task build`.

--- a/internal/analyzer/tiered.go
+++ b/internal/analyzer/tiered.go
@@ -371,13 +371,6 @@ func (ta *TieredAnalyzer) runRegexRules(art input.Artifact, regexRules []rules.R
 				"gavel/rule-source":  string(rule.Source),
 			}
 
-			// Add standard references if available
-			if len(rule.CWE) > 0 {
-				props["gavel/cwe"] = rule.CWE
-			}
-			if len(rule.OWASP) > 0 {
-				props["gavel/owasp"] = rule.OWASP
-			}
 			if rule.Remediation != "" {
 				props["gavel/remediation"] = rule.Remediation
 			}
@@ -460,12 +453,6 @@ func (ta *TieredAnalyzer) runASTRules(art input.Artifact, astRules []rules.Rule)
 				"gavel/tier":        "instant",
 				"gavel/rule-type":   "ast",
 				"gavel/rule-source": string(rule.Source),
-			}
-			if len(rule.CWE) > 0 {
-				props["gavel/cwe"] = rule.CWE
-			}
-			if len(rule.OWASP) > 0 {
-				props["gavel/owasp"] = rule.OWASP
 			}
 			if rule.Remediation != "" {
 				props["gavel/remediation"] = rule.Remediation

--- a/internal/output/sarif_test.go
+++ b/internal/output/sarif_test.go
@@ -35,7 +35,6 @@ func testSARIFLog() *sarif.Log {
 					Properties: map[string]any{
 						"gavel/confidence": 0.95,
 						"gavel/tier":       "comprehensive",
-						"gavel/cwe":        []string{"CWE-798"},
 					},
 				},
 			},

--- a/internal/rules/sarif.go
+++ b/internal/rules/sarif.go
@@ -32,6 +32,26 @@ func (r Rule) ToSARIFDescriptor() sarif.ReportingDescriptor {
 
 	d.HelpURI = resolveHelpURI(r)
 
+	for _, cwe := range r.CWE {
+		id := strings.TrimPrefix(cwe, "CWE-")
+		d.Relationships = append(d.Relationships, sarif.Relationship{
+			Target: sarif.RelationshipTarget{
+				ID:            id,
+				ToolComponent: &sarif.ToolComponentReference{Name: "CWE"},
+			},
+			Kinds: []string{"relevant"},
+		})
+	}
+	for _, owasp := range r.OWASP {
+		d.Relationships = append(d.Relationships, sarif.Relationship{
+			Target: sarif.RelationshipTarget{
+				ID:            owasp,
+				ToolComponent: &sarif.ToolComponentReference{Name: "OWASP"},
+			},
+			Kinds: []string{"relevant"},
+		})
+	}
+
 	return d
 }
 

--- a/internal/rules/sarif.go
+++ b/internal/rules/sarif.go
@@ -1,7 +1,6 @@
 package rules
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/chris-regnier/gavel/internal/sarif"
@@ -55,10 +54,12 @@ func (r Rule) ToSARIFDescriptor() sarif.ReportingDescriptor {
 	return d
 }
 
-// buildHelp assembles a MultiformatMessage from remediation, CWE/OWASP,
-// and reference links. Returns nil when no help content is available.
+// buildHelp assembles a MultiformatMessage from remediation and reference
+// links. Returns nil when no help content is available.
+// CWE/OWASP references are no longer included here — they are represented
+// as first-class reportingDescriptor.relationships instead.
 func buildHelp(r Rule) *sarif.MultiformatMessage {
-	if r.Remediation == "" && len(r.CWE) == 0 && len(r.OWASP) == 0 && len(r.References) == 0 {
+	if r.Remediation == "" && len(r.References) == 0 {
 		return nil
 	}
 
@@ -68,21 +69,6 @@ func buildHelp(r Rule) *sarif.MultiformatMessage {
 	if r.Remediation != "" {
 		textParts = append(textParts, r.Remediation)
 		mdParts = append(mdParts, "**Remediation:** "+r.Remediation)
-	}
-
-	if len(r.CWE) > 0 {
-		var cweLinks []string
-		for _, id := range r.CWE {
-			cweLinks = append(cweLinks, fmt.Sprintf("[%s](%s)", id, cweURL(id)))
-		}
-		textParts = append(textParts, "CWE: "+strings.Join(r.CWE, ", "))
-		mdParts = append(mdParts, "**CWE:** "+strings.Join(cweLinks, ", "))
-	}
-
-	if len(r.OWASP) > 0 {
-		joined := strings.Join(r.OWASP, ", ")
-		textParts = append(textParts, "OWASP: "+joined)
-		mdParts = append(mdParts, "**OWASP:** "+joined)
 	}
 
 	if len(r.References) > 0 {

--- a/internal/rules/sarif_test.go
+++ b/internal/rules/sarif_test.go
@@ -51,14 +51,15 @@ func TestToSARIFDescriptor_AllFields(t *testing.T) {
 	if !strings.Contains(d.Help.Markdown, "**Remediation:**") {
 		t.Errorf("Help.Markdown: expected remediation heading, got %q", d.Help.Markdown)
 	}
-	if !strings.Contains(d.Help.Markdown, "CWE-798") {
-		t.Errorf("Help.Markdown: expected CWE-798 reference, got %q", d.Help.Markdown)
+	// CWE/OWASP should NOT appear in help text — they are in relationships now.
+	if strings.Contains(d.Help.Markdown, "**CWE:**") {
+		t.Errorf("Help.Markdown: should not contain CWE section, got %q", d.Help.Markdown)
+	}
+	if strings.Contains(d.Help.Markdown, "**OWASP:**") {
+		t.Errorf("Help.Markdown: should not contain OWASP section, got %q", d.Help.Markdown)
 	}
 	if !strings.Contains(d.Help.Markdown, "https://cwe.mitre.org/data/definitions/798.html") {
 		t.Errorf("Help.Markdown: expected reference URL, got %q", d.Help.Markdown)
-	}
-	if !strings.Contains(d.Help.Markdown, "A07:2021") {
-		t.Errorf("Help.Markdown: expected OWASP entry, got %q", d.Help.Markdown)
 	}
 	// Reference list items must not be separated by blank lines - that would
 	// render each item as a separate paragraph in markdown viewers.
@@ -138,15 +139,20 @@ func TestToSARIFDescriptor_CWEWithoutReferences(t *testing.T) {
 
 	d := r.ToSARIFDescriptor()
 
-	if d.Help == nil {
-		t.Fatal("Help: expected populated, got nil")
+	// No remediation and no references → Help should be nil (CWE is in relationships now).
+	if d.Help != nil {
+		t.Errorf("Help: expected nil for CWE-only rule, got %+v", d.Help)
 	}
-	if !strings.Contains(d.Help.Markdown, "CWE-89") {
-		t.Errorf("Help.Markdown: expected CWE-89, got %q", d.Help.Markdown)
-	}
-	// HelpURI should fall back to the synthesized cwe.mitre.org URL.
+	// HelpURI should still fall back to the synthesized cwe.mitre.org URL.
 	if d.HelpURI != "https://cwe.mitre.org/data/definitions/89.html" {
 		t.Errorf("HelpURI: expected synthesized CWE URL, got %q", d.HelpURI)
+	}
+	// Relationships should be populated.
+	if len(d.Relationships) != 1 {
+		t.Fatalf("expected 1 relationship, got %d", len(d.Relationships))
+	}
+	if d.Relationships[0].Target.ID != "89" {
+		t.Errorf("relationship target: expected 89, got %q", d.Relationships[0].Target.ID)
 	}
 }
 

--- a/internal/rules/sarif_test.go
+++ b/internal/rules/sarif_test.go
@@ -149,3 +149,59 @@ func TestToSARIFDescriptor_CWEWithoutReferences(t *testing.T) {
 		t.Errorf("HelpURI: expected synthesized CWE URL, got %q", d.HelpURI)
 	}
 }
+
+func TestToSARIFDescriptor_Relationships(t *testing.T) {
+	r := Rule{
+		ID:         "S2068",
+		Level:      "error",
+		Confidence: 0.85,
+		Message:    "Hard-coded credentials detected",
+		CWE:        []string{"CWE-259", "CWE-798"},
+		OWASP:      []string{"A07:2021"},
+	}
+
+	d := r.ToSARIFDescriptor()
+
+	if len(d.Relationships) != 3 {
+		t.Fatalf("expected 3 relationships, got %d", len(d.Relationships))
+	}
+
+	rel0 := d.Relationships[0]
+	if rel0.Target.ID != "259" {
+		t.Errorf("rel[0] target ID: expected 259, got %q", rel0.Target.ID)
+	}
+	if rel0.Target.ToolComponent == nil || rel0.Target.ToolComponent.Name != "CWE" {
+		t.Errorf("rel[0] toolComponent: got %+v", rel0.Target.ToolComponent)
+	}
+	if len(rel0.Kinds) != 1 || rel0.Kinds[0] != "relevant" {
+		t.Errorf("rel[0] kinds: got %v", rel0.Kinds)
+	}
+
+	rel1 := d.Relationships[1]
+	if rel1.Target.ID != "798" {
+		t.Errorf("rel[1] target ID: expected 798, got %q", rel1.Target.ID)
+	}
+
+	rel2 := d.Relationships[2]
+	if rel2.Target.ID != "A07:2021" {
+		t.Errorf("rel[2] target ID: expected A07:2021, got %q", rel2.Target.ID)
+	}
+	if rel2.Target.ToolComponent == nil || rel2.Target.ToolComponent.Name != "OWASP" {
+		t.Errorf("rel[2] toolComponent: got %+v", rel2.Target.ToolComponent)
+	}
+}
+
+func TestToSARIFDescriptor_NoRelationshipsForMinimalRule(t *testing.T) {
+	r := Rule{
+		ID:         "R001",
+		Level:      "warning",
+		Confidence: 0.5,
+		Message:    "found foo",
+	}
+
+	d := r.ToSARIFDescriptor()
+
+	if len(d.Relationships) != 0 {
+		t.Errorf("expected no relationships for minimal rule, got %d", len(d.Relationships))
+	}
+}

--- a/internal/sarif/assembler.go
+++ b/internal/sarif/assembler.go
@@ -6,6 +6,7 @@ func Assemble(results []Result, rules []ReportingDescriptor, inputScope, persona
 
 	log := NewLog("gavel", "0.1.0")
 	log.Runs[0].Tool.Driver.Rules = rules
+	log.Runs[0].Taxonomies = BuildTaxonomies(rules)
 	log.Runs[0].Results = deduped
 	log.Runs[0].Properties = map[string]interface{}{
 		"gavel/inputScope": inputScope,

--- a/internal/sarif/assembler_test.go
+++ b/internal/sarif/assembler_test.go
@@ -142,3 +142,35 @@ func TestAssembler_AddsCacheMetadata(t *testing.T) {
 		t.Fatal("Expected policies in analyzer metadata")
 	}
 }
+
+func TestAssemble_Taxonomies(t *testing.T) {
+	rules := []ReportingDescriptor{{
+		ID: "S2068",
+		Relationships: []Relationship{
+			{Target: RelationshipTarget{ID: "798", ToolComponent: &ToolComponentReference{Name: "CWE"}}},
+			{Target: RelationshipTarget{ID: "A07:2021", ToolComponent: &ToolComponentReference{Name: "OWASP"}}},
+		},
+	}}
+
+	log := Assemble(nil, rules, "files", "code-reviewer")
+
+	if len(log.Runs[0].Taxonomies) != 2 {
+		t.Fatalf("expected 2 taxonomies, got %d", len(log.Runs[0].Taxonomies))
+	}
+	if log.Runs[0].Taxonomies[0].Name != "CWE" {
+		t.Errorf("first taxonomy: expected CWE, got %q", log.Runs[0].Taxonomies[0].Name)
+	}
+	if log.Runs[0].Taxonomies[1].Name != "OWASP" {
+		t.Errorf("second taxonomy: expected OWASP, got %q", log.Runs[0].Taxonomies[1].Name)
+	}
+}
+
+func TestAssemble_NoTaxonomiesWhenNoRelationships(t *testing.T) {
+	rules := []ReportingDescriptor{{ID: "R001"}}
+
+	log := Assemble(nil, rules, "files", "code-reviewer")
+
+	if log.Runs[0].Taxonomies != nil {
+		t.Errorf("expected nil taxonomies, got %+v", log.Runs[0].Taxonomies)
+	}
+}

--- a/internal/sarif/builder.go
+++ b/internal/sarif/builder.go
@@ -107,6 +107,7 @@ func (a *Assembler) Build() *Log {
 	// Create log
 	log := NewLog("gavel", "0.1.0")
 	log.Runs[0].Tool.Driver.Rules = a.rules
+	log.Runs[0].Taxonomies = BuildTaxonomies(a.rules)
 	log.Runs[0].Results = deduped
 
 	if a.inputScope != "" {

--- a/internal/sarif/sarif.go
+++ b/internal/sarif/sarif.go
@@ -40,6 +40,26 @@ type ReportingDescriptor struct {
 	Help             *MultiformatMessage     `json:"help,omitempty"`
 	HelpURI          string                  `json:"helpUri,omitempty"`
 	DefaultConfig    *ReportingConfiguration `json:"defaultConfiguration,omitempty"`
+	Relationships    []Relationship          `json:"relationships,omitempty"`
+}
+
+// Relationship represents a reportingDescriptorRelationship (§3.52) on a
+// rule descriptor, linking it to a taxon in an external taxonomy such as CWE
+// or OWASP.
+type Relationship struct {
+	Target RelationshipTarget `json:"target"`
+	Kinds  []string           `json:"kinds,omitempty"`
+}
+
+// RelationshipTarget identifies a specific taxon within a named toolComponent.
+type RelationshipTarget struct {
+	ID            string                 `json:"id"`
+	ToolComponent *ToolComponentReference `json:"toolComponent,omitempty"`
+}
+
+// ToolComponentReference identifies a toolComponent by name.
+type ToolComponentReference struct {
+	Name string `json:"name"`
 }
 
 type ReportingConfiguration struct {

--- a/internal/sarif/sarif.go
+++ b/internal/sarif/sarif.go
@@ -12,6 +12,7 @@ type Log struct {
 type Run struct {
 	Tool        Tool                   `json:"tool"`
 	Results     []Result               `json:"results"`
+	Taxonomies  []ToolComponent        `json:"taxonomies,omitempty"`
 	Invocations []Invocation           `json:"invocations,omitempty"`
 	Properties  map[string]interface{} `json:"properties,omitempty"`
 }
@@ -60,6 +61,21 @@ type RelationshipTarget struct {
 // ToolComponentReference identifies a toolComponent by name.
 type ToolComponentReference struct {
 	Name string `json:"name"`
+}
+
+// ToolComponent represents a SARIF toolComponent (§3.19). Used inside
+// Run.Taxonomies to describe a taxonomy (e.g., CWE, OWASP) and its taxa.
+type ToolComponent struct {
+	Name         string  `json:"name"`
+	Organization string  `json:"organization,omitempty"`
+	Taxa         []Taxon `json:"taxa,omitempty"`
+}
+
+// Taxon represents an entry in a taxonomy (a reportingDescriptor used as
+// a taxon, §3.19.6).
+type Taxon struct {
+	ID   string `json:"id"`
+	Name string `json:"name,omitempty"`
 }
 
 type ReportingConfiguration struct {

--- a/internal/sarif/sarif_test.go
+++ b/internal/sarif/sarif_test.go
@@ -57,9 +57,16 @@ func TestReportingDescriptor_HelpMarshaling(t *testing.T) {
 		ShortDescription: Message{Text: "Hard-coded credentials detected"},
 		FullDescription:  &Message{Text: "Credentials should not be hard-coded."},
 		Help: &MultiformatMessage{
-			Text:     "Use environment variables.\n\nCWE: CWE-798",
-			Markdown: "**Remediation:** Use environment variables.\n\n**CWE:** [CWE-798](https://cwe.mitre.org/data/definitions/798.html)",
+			Text:     "Use environment variables.",
+			Markdown: "**Remediation:** Use environment variables.",
 		},
+		Relationships: []Relationship{{
+			Target: RelationshipTarget{
+				ID:            "798",
+				ToolComponent: &ToolComponentReference{Name: "CWE"},
+			},
+			Kinds: []string{"relevant"},
+		}},
 		HelpURI:       "https://cwe.mitre.org/data/definitions/798.html",
 		DefaultConfig: &ReportingConfiguration{Level: "error"},
 	}}

--- a/internal/sarif/sarif_test.go
+++ b/internal/sarif/sarif_test.go
@@ -102,6 +102,93 @@ func TestReportingDescriptor_HelpMarshaling(t *testing.T) {
 	}
 }
 
+func TestTaxonomyTypes_MarshalJSON(t *testing.T) {
+	log := NewLog("gavel", "0.1.0")
+	log.Runs[0].Tool.Driver.Rules = []ReportingDescriptor{{
+		ID:               "S2068",
+		Name:             "hardcoded-credentials",
+		ShortDescription: Message{Text: "Hard-coded credentials detected"},
+		Relationships: []Relationship{{
+			Target: RelationshipTarget{
+				ID:            "798",
+				ToolComponent: &ToolComponentReference{Name: "CWE"},
+			},
+			Kinds: []string{"relevant"},
+		}},
+	}}
+	log.Runs[0].Taxonomies = []ToolComponent{{
+		Name:         "CWE",
+		Organization: "MITRE",
+		Taxa:         []Taxon{{ID: "798"}},
+	}}
+
+	data, err := json.Marshal(log)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(data)
+
+	for _, want := range []string{
+		`"taxonomies"`,
+		`"taxa"`,
+		`"relationships"`,
+		`"toolComponent"`,
+		`"kinds":["relevant"]`,
+	} {
+		if !contains(s, want) {
+			t.Errorf("expected JSON to contain %s", want)
+		}
+	}
+
+	// Round-trip
+	var parsed Log
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatal(err)
+	}
+	if len(parsed.Runs[0].Taxonomies) != 1 {
+		t.Fatalf("expected 1 taxonomy, got %d", len(parsed.Runs[0].Taxonomies))
+	}
+	tax := parsed.Runs[0].Taxonomies[0]
+	if tax.Name != "CWE" || tax.Organization != "MITRE" {
+		t.Errorf("taxonomy: got name=%q org=%q", tax.Name, tax.Organization)
+	}
+	if len(tax.Taxa) != 1 || tax.Taxa[0].ID != "798" {
+		t.Errorf("taxa: got %+v", tax.Taxa)
+	}
+
+	rule := parsed.Runs[0].Tool.Driver.Rules[0]
+	if len(rule.Relationships) != 1 {
+		t.Fatalf("expected 1 relationship, got %d", len(rule.Relationships))
+	}
+	rel := rule.Relationships[0]
+	if rel.Target.ID != "798" {
+		t.Errorf("relationship target ID: got %q", rel.Target.ID)
+	}
+	if rel.Target.ToolComponent == nil || rel.Target.ToolComponent.Name != "CWE" {
+		t.Errorf("relationship toolComponent: got %+v", rel.Target.ToolComponent)
+	}
+}
+
+func TestTaxonomyTypes_OmitEmpty(t *testing.T) {
+	log := NewLog("gavel", "0.1.0")
+	log.Runs[0].Tool.Driver.Rules = []ReportingDescriptor{{
+		ID:               "R001",
+		ShortDescription: Message{Text: "test"},
+	}}
+
+	data, err := json.Marshal(log)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(data)
+
+	for _, absent := range []string{"taxonomies", "relationships"} {
+		if contains(s, absent) {
+			t.Errorf("expected JSON to NOT contain %q when empty", absent)
+		}
+	}
+}
+
 func contains(s, substr string) bool {
 	for i := 0; i+len(substr) <= len(s); i++ {
 		if s[i:i+len(substr)] == substr {

--- a/internal/sarif/taxonomies.go
+++ b/internal/sarif/taxonomies.go
@@ -1,0 +1,53 @@
+package sarif
+
+import "sort"
+
+// taxonomyOrgs maps well-known taxonomy names to their organizations.
+var taxonomyOrgs = map[string]string{
+	"CWE":   "MITRE",
+	"OWASP": "OWASP Foundation",
+}
+
+// BuildTaxonomies walks the Relationships of each rule and returns the
+// unique set of SARIF toolComponents referenced, each populated with its
+// taxa. Taxa and taxonomies are sorted deterministically. Returns nil when
+// no relationships reference a toolComponent.
+func BuildTaxonomies(rules []ReportingDescriptor) []ToolComponent {
+	groups := make(map[string]map[string]struct{})
+
+	for _, rule := range rules {
+		for _, rel := range rule.Relationships {
+			if rel.Target.ToolComponent == nil {
+				continue
+			}
+			name := rel.Target.ToolComponent.Name
+			if _, ok := groups[name]; !ok {
+				groups[name] = make(map[string]struct{})
+			}
+			groups[name][rel.Target.ID] = struct{}{}
+		}
+	}
+
+	if len(groups) == 0 {
+		return nil
+	}
+
+	var result []ToolComponent
+	for name, ids := range groups {
+		taxa := make([]Taxon, 0, len(ids))
+		for id := range ids {
+			taxa = append(taxa, Taxon{ID: id})
+		}
+		sort.Slice(taxa, func(i, j int) bool { return taxa[i].ID < taxa[j].ID })
+
+		tc := ToolComponent{
+			Name:         name,
+			Organization: taxonomyOrgs[name],
+			Taxa:         taxa,
+		}
+		result = append(result, tc)
+	}
+
+	sort.Slice(result, func(i, j int) bool { return result[i].Name < result[j].Name })
+	return result
+}

--- a/internal/sarif/taxonomies_test.go
+++ b/internal/sarif/taxonomies_test.go
@@ -1,0 +1,136 @@
+package sarif
+
+import (
+	"testing"
+)
+
+func TestBuildTaxonomies_Empty(t *testing.T) {
+	result := BuildTaxonomies(nil)
+	if result != nil {
+		t.Errorf("expected nil for empty input, got %+v", result)
+	}
+
+	result = BuildTaxonomies([]ReportingDescriptor{})
+	if result != nil {
+		t.Errorf("expected nil for no-relationship input, got %+v", result)
+	}
+}
+
+func TestBuildTaxonomies_SingleCWE(t *testing.T) {
+	rules := []ReportingDescriptor{{
+		ID: "S001",
+		Relationships: []Relationship{{
+			Target: RelationshipTarget{
+				ID:            "798",
+				ToolComponent: &ToolComponentReference{Name: "CWE"},
+			},
+			Kinds: []string{"relevant"},
+		}},
+	}}
+
+	result := BuildTaxonomies(rules)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 taxonomy, got %d", len(result))
+	}
+	if result[0].Name != "CWE" {
+		t.Errorf("name: got %q", result[0].Name)
+	}
+	if result[0].Organization != "MITRE" {
+		t.Errorf("organization: got %q", result[0].Organization)
+	}
+	if len(result[0].Taxa) != 1 || result[0].Taxa[0].ID != "798" {
+		t.Errorf("taxa: got %+v", result[0].Taxa)
+	}
+}
+
+func TestBuildTaxonomies_MultipleCWEs(t *testing.T) {
+	rules := []ReportingDescriptor{{
+		ID: "S001",
+		Relationships: []Relationship{
+			{Target: RelationshipTarget{ID: "798", ToolComponent: &ToolComponentReference{Name: "CWE"}}},
+			{Target: RelationshipTarget{ID: "259", ToolComponent: &ToolComponentReference{Name: "CWE"}}},
+		},
+	}}
+
+	result := BuildTaxonomies(rules)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 taxonomy, got %d", len(result))
+	}
+	if len(result[0].Taxa) != 2 {
+		t.Fatalf("expected 2 taxa, got %d", len(result[0].Taxa))
+	}
+	if result[0].Taxa[0].ID != "259" || result[0].Taxa[1].ID != "798" {
+		t.Errorf("taxa not sorted: %+v", result[0].Taxa)
+	}
+}
+
+func TestBuildTaxonomies_DedupAcrossRules(t *testing.T) {
+	rules := []ReportingDescriptor{
+		{
+			ID:            "S001",
+			Relationships: []Relationship{{Target: RelationshipTarget{ID: "798", ToolComponent: &ToolComponentReference{Name: "CWE"}}}},
+		},
+		{
+			ID:            "S002",
+			Relationships: []Relationship{{Target: RelationshipTarget{ID: "798", ToolComponent: &ToolComponentReference{Name: "CWE"}}}},
+		},
+	}
+
+	result := BuildTaxonomies(rules)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 taxonomy, got %d", len(result))
+	}
+	if len(result[0].Taxa) != 1 {
+		t.Errorf("expected dedup to 1 taxon, got %d", len(result[0].Taxa))
+	}
+}
+
+func TestBuildTaxonomies_MixedCWEAndOWASP(t *testing.T) {
+	rules := []ReportingDescriptor{{
+		ID: "S001",
+		Relationships: []Relationship{
+			{Target: RelationshipTarget{ID: "798", ToolComponent: &ToolComponentReference{Name: "CWE"}}},
+			{Target: RelationshipTarget{ID: "A07:2021", ToolComponent: &ToolComponentReference{Name: "OWASP"}}},
+		},
+	}}
+
+	result := BuildTaxonomies(rules)
+	if len(result) != 2 {
+		t.Fatalf("expected 2 taxonomies, got %d", len(result))
+	}
+	if result[0].Name != "CWE" || result[1].Name != "OWASP" {
+		t.Errorf("taxonomy order: got [%q, %q]", result[0].Name, result[1].Name)
+	}
+	if result[0].Organization != "MITRE" {
+		t.Errorf("CWE org: got %q", result[0].Organization)
+	}
+	if result[1].Organization != "OWASP Foundation" {
+		t.Errorf("OWASP org: got %q", result[1].Organization)
+	}
+}
+
+func TestBuildTaxonomies_NoRelationships(t *testing.T) {
+	rules := []ReportingDescriptor{
+		{ID: "R001"},
+		{ID: "R002"},
+	}
+
+	result := BuildTaxonomies(rules)
+	if result != nil {
+		t.Errorf("expected nil for rules with no relationships, got %+v", result)
+	}
+}
+
+func TestBuildTaxonomies_NilToolComponent(t *testing.T) {
+	rules := []ReportingDescriptor{{
+		ID: "S001",
+		Relationships: []Relationship{{
+			Target: RelationshipTarget{ID: "798"},
+		}},
+	}}
+
+	result := BuildTaxonomies(rules)
+	if result != nil {
+		t.Errorf("expected nil for nil toolComponent, got %+v", result)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #77

- Replace custom `gavel/cwe` and `gavel/owasp` result properties with SARIF-standard `run.taxonomies` array and `reportingDescriptor.relationships`
- Add `BuildTaxonomies()` pure function that aggregates CWE/OWASP taxa from rule relationships with deterministic ordering and deduplication
- Populate `relationships` on rule descriptors via `ToSARIFDescriptor()`, stripping `CWE-` prefix for taxon IDs and using `"relevant"` kind
- Remove CWE/OWASP sections from rule help text (now first-class on the descriptor)
- Update `docs/reference/sarif.md` with new Taxonomies section

## Test plan

- [x] 7 table-driven tests for `BuildTaxonomies` (empty, single CWE, multiple CWEs, dedup, mixed CWE+OWASP, no relationships, nil toolComponent)
- [x] 2 tests for relationship population on rule descriptors
- [x] Updated 3 existing `rules/sarif_test.go` tests for new help format
- [x] 2 assembler tests verifying taxonomies are populated / nil when no relationships
- [x] 2 JSON serialization tests for new types (marshal round-trip + omitempty)
- [x] `task lint` clean, `task test` all pass, `task build` succeeds
- [x] Ran gavel self-review on all changed files — no actionable findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)