### PR TITLE
ci(release): pin baml-cli and goimports via composite action

### DIFF
--- a/.github/actions/install-tools/action.yml
+++ b/.github/actions/install-tools/action.yml
@@ -1,0 +1,40 @@
+name: 'Install pinned Gavel dev tools'
+description: 'Installs baml-cli and goimports at pinned versions (single source of truth for all workflows).'
+
+# ---------------------------------------------------------------------------
+# Upgrade procedure
+# ---------------------------------------------------------------------------
+# Bumping a pin is intentionally a one-line change. To upgrade:
+#
+#   1. Edit the `default:` value for the relevant input below.
+#   2. Keep `baml-cli-version` in sync with the `github.com/boundaryml/baml`
+#      version pinned in `go.mod` so the CLI and the generated client stay
+#      compatible.
+#   3. Keep `goimports-version` in sync with the `golang.org/x/tools` version
+#      resolved in `go.sum` (goimports ships from the same module).
+#   4. Run `task generate && task check` locally, commit, and push.
+#
+# Do NOT reintroduce `@latest` here or in any workflow — reproducible release
+# builds depend on these pins. See chris-regnier/gavel#88.
+# ---------------------------------------------------------------------------
+
+inputs:
+  baml-cli-version:
+    description: 'BAML CLI version (must match github.com/boundaryml/baml in go.mod).'
+    required: false
+    default: 'v0.220.0'
+  goimports-version:
+    description: 'goimports version (must match golang.org/x/tools in go.sum).'
+    required: false
+    default: 'v0.40.0'
+
+runs:
+  using: composite
+  steps:
+    - name: Install BAML CLI (pinned)
+      shell: bash
+      run: go install "github.com/boundaryml/baml/baml-cli@${{ inputs.baml-cli-version }}"
+
+    - name: Install goimports (pinned)
+      shell: bash
+      run: go install "golang.org/x/tools/cmd/goimports@${{ inputs.goimports-version }}"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -31,8 +31,8 @@ jobs:
         with:
           go-version: '1.25'
 
-      - name: Install BAML CLI
-        run: go install github.com/boundaryml/baml/baml-cli@latest
+      - name: Install pinned dev tools
+        uses: ./.github/actions/install-tools
 
       - name: Generate BAML client
         run: baml-cli generate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,8 @@ jobs:
           go-version: '1.25'
           cache: true
 
-      - name: Install BAML CLI
-        run: go install github.com/boundaryml/baml/baml-cli@latest
-
-      - name: Install goimports
-        run: go install golang.org/x/tools/cmd/goimports@latest
+      - name: Install pinned dev tools
+        uses: ./.github/actions/install-tools
 
       - name: Install Task
         uses: go-task/setup-task@v1

--- a/.github/workflows/gavel.yml
+++ b/.github/workflows/gavel.yml
@@ -150,11 +150,8 @@ jobs:
           go-version: '1.25'
           cache: true
 
-      - name: Install BAML CLI
-        run: go install github.com/boundaryml/baml/baml-cli@latest
-
-      - name: Install goimports
-        run: go install golang.org/x/tools/cmd/goimports@latest
+      - name: Install pinned dev tools
+        uses: ./.github/actions/install-tools
 
       - name: Install Task
         uses: go-task/setup-task@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,11 +22,8 @@ jobs:
         with:
           go-version: '1.25'
 
-      - name: Install BAML CLI
-        run: go install github.com/boundaryml/baml/baml-cli@latest
-
-      - name: Install goimports
-        run: go install golang.org/x/tools/cmd/goimports@latest
+      - name: Install pinned dev tools
+        uses: ./.github/actions/install-tools
 
       - name: Install cross-compilation toolchain
         run: |
@@ -62,11 +59,8 @@ jobs:
         with:
           go-version: '1.25'
 
-      - name: Install BAML CLI
-        run: go install github.com/boundaryml/baml/baml-cli@latest
-
-      - name: Install goimports
-        run: go install golang.org/x/tools/cmd/goimports@latest
+      - name: Install pinned dev tools
+        uses: ./.github/actions/install-tools
 
       - name: Install Task
         uses: go-task/setup-task@v1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,3 +208,9 @@ task build:release      # All architectures for current OS
 - CGO must be enabled (BAML dependency requires it)
 - macOS builds require Xcode tools
 - Linux builds use system GCC
+
+**Pinned CI tooling:**
+
+`baml-cli` and `goimports` are installed at pinned versions in every workflow via the `./.github/actions/install-tools` composite action. CI and release builds must be reproducible — do NOT reintroduce `@latest` in any workflow.
+
+To upgrade a pin, edit the `default:` value of the relevant input in `.github/actions/install-tools/action.yml` (one-line change), then run `task generate && task check` locally. Keep `baml-cli-version` in sync with `github.com/boundaryml/baml` in `go.mod`, and `goimports-version` in sync with `golang.org/x/tools` in `go.sum`. See chris-regnier/gavel#88 for background.


### PR DESCRIPTION
Replace the @latest installs of baml-cli and goimports in every workflow
with a single composite action at .github/actions/install-tools. Versions
are pinned to v0.220.0 (matching github.com/boundaryml/baml in go.mod)
and v0.40.0 (matching golang.org/x/tools in go.sum), so release builds
are reproducible and CI can no longer go red from upstream bumps.

Upgrading is a one-line change to the action's input defaults. Closes #88.