### PR TITLE
feat(sarif): add content-based fingerprints stable across line shifts

### DIFF
--- a/internal/output/sarif.go
+++ b/internal/output/sarif.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/chris-regnier/gavel/internal/sarif"
 )
@@ -57,7 +58,7 @@ func enrichRun(run *sarif.Run) {
 	}
 }
 
-// enrichResult adds partial fingerprints, security-severity, and precision
+// enrichResult adds fingerprints, security-severity, and precision
 // to a single SARIF result.
 func enrichResult(r *sarif.Result) {
 	// Initialize maps if needed.
@@ -68,18 +69,38 @@ func enrichResult(r *sarif.Result) {
 		r.Properties = make(map[string]any)
 	}
 
-	// Compute partial fingerprint from ruleID, URI, startLine, and message.
+	// Extract location info once.
 	uri := ""
 	startLine := 0
+	var snippet string
 	if len(r.Locations) > 0 {
 		loc := r.Locations[0]
 		uri = loc.PhysicalLocation.ArtifactLocation.URI
 		startLine = loc.PhysicalLocation.Region.StartLine
+		if loc.PhysicalLocation.Region.Snippet != nil {
+			snippet = loc.PhysicalLocation.Region.Snippet.Text
+		}
 	}
 
+	// Compute partial fingerprint from ruleID, URI, startLine, and message.
+	// This is line-positional and breaks when lines shift.
 	fingerprintInput := fmt.Sprintf("%s|%s|%d|%s", r.RuleID, uri, startLine, r.Message.Text)
 	hash := sha256.Sum256([]byte(fingerprintInput))
 	r.PartialFingerprints["primaryLocationLineHash"] = fmt.Sprintf("%x", hash[:16]) // first 32 hex chars (16 bytes)
+
+	// Compute content-based fingerprint that survives line shifts and
+	// whitespace-only reformatting. We hash the rule ID together with the
+	// snippet text after normalizing whitespace (trim each line, drop blank
+	// lines). When no snippet is available we skip the content fingerprint;
+	// the partialFingerprint above still provides a positional identity.
+	if normalized := normalizeSnippet(snippet); normalized != "" {
+		if r.Fingerprints == nil {
+			r.Fingerprints = make(map[string]string)
+		}
+		contentInput := r.RuleID + "\n" + normalized
+		contentHash := sha256.Sum256([]byte(contentInput))
+		r.Fingerprints["gavel/contentHash/v1"] = fmt.Sprintf("%x", contentHash[:16])
+	}
 
 	// Map level to security-severity score.
 	r.Properties["security-severity"] = securitySeverity(r.Level)
@@ -87,6 +108,27 @@ func enrichResult(r *sarif.Result) {
 	// Map tier to precision.
 	tier, _ := r.Properties["gavel/tier"].(string)
 	r.Properties["precision"] = tierPrecision(tier)
+}
+
+// normalizeSnippet returns a whitespace-normalized form of a code snippet
+// suitable for content-based fingerprinting. Each line is trimmed of leading
+// and trailing whitespace and blank lines are dropped, so reformatting that
+// only changes indentation or blank-line padding produces the same hash.
+// Returns "" if the snippet contains no non-whitespace content.
+func normalizeSnippet(s string) string {
+	if s == "" {
+		return ""
+	}
+	lines := strings.Split(s, "\n")
+	out := make([]string, 0, len(lines))
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		out = append(out, trimmed)
+	}
+	return strings.Join(out, "\n")
 }
 
 // securitySeverity maps SARIF levels to GitHub Code Scanning security-severity scores.

--- a/internal/output/sarif_test.go
+++ b/internal/output/sarif_test.go
@@ -88,6 +88,121 @@ func TestSARIFFormatter_ValidJSON(t *testing.T) {
 	}
 }
 
+// snippetSARIFLog returns a SARIF log whose first result carries a snippet,
+// allowing tests to exercise the content-based fingerprint path.
+func snippetSARIFLog(ruleID, uri, snippetText string, startLine int) *sarif.Log {
+	log := testSARIFLog()
+	r := &log.Runs[0].Results[0]
+	r.RuleID = ruleID
+	r.Locations = []sarif.Location{{
+		PhysicalLocation: sarif.PhysicalLocation{
+			ArtifactLocation: sarif.ArtifactLocation{URI: uri},
+			Region: sarif.Region{
+				StartLine: startLine,
+				EndLine:   startLine,
+				Snippet:   &sarif.ArtifactContent{Text: snippetText},
+			},
+		},
+	}}
+	return log
+}
+
+func formatAndParse(t *testing.T, log *sarif.Log) sarif.Log {
+	t.Helper()
+	f := &SARIFFormatter{}
+	out, err := f.Format(&AnalysisOutput{SARIFLog: log})
+	if err != nil {
+		t.Fatalf("Format() returned error: %v", err)
+	}
+	var parsed sarif.Log
+	if err := json.Unmarshal(out, &parsed); err != nil {
+		t.Fatalf("output is not valid SARIF JSON: %v", err)
+	}
+	return parsed
+}
+
+func TestSARIFFormatter_HasContentFingerprint(t *testing.T) {
+	log := snippetSARIFLog("SEC001", "config/db.go", "password := \"hunter2\"\n", 42)
+	parsed := formatAndParse(t, log)
+
+	r := parsed.Runs[0].Results[0]
+	if r.Fingerprints == nil {
+		t.Fatal("expected fingerprints to be set")
+	}
+
+	hash, ok := r.Fingerprints["gavel/contentHash/v1"]
+	if !ok {
+		t.Fatal("expected fingerprints to contain 'gavel/contentHash/v1'")
+	}
+	if len(hash) != 32 {
+		t.Errorf("contentHash length = %d, want 32 hex chars; value = %q", len(hash), hash)
+	}
+}
+
+func TestSARIFFormatter_ContentFingerprint_StableAcrossLineShifts(t *testing.T) {
+	snippet := "password := \"hunter2\"\n"
+	a := formatAndParse(t, snippetSARIFLog("SEC001", "config/db.go", snippet, 42))
+	// Same snippet at a different line and a different file path; the content
+	// hash should ignore both because it depends only on rule + content.
+	b := formatAndParse(t, snippetSARIFLog("SEC001", "other/path.go", snippet, 99))
+
+	hashA := a.Runs[0].Results[0].Fingerprints["gavel/contentHash/v1"]
+	hashB := b.Runs[0].Results[0].Fingerprints["gavel/contentHash/v1"]
+	if hashA == "" || hashB == "" {
+		t.Fatalf("missing content fingerprints: a=%q b=%q", hashA, hashB)
+	}
+	if hashA != hashB {
+		t.Errorf("contentHash should be stable across line shifts; got %q vs %q", hashA, hashB)
+	}
+
+	// And the legacy partialFingerprint must shift, since startLine differs.
+	pfA := a.Runs[0].Results[0].PartialFingerprints["primaryLocationLineHash"]
+	pfB := b.Runs[0].Results[0].PartialFingerprints["primaryLocationLineHash"]
+	if pfA == pfB {
+		t.Errorf("partialFingerprint should differ when startLine/uri change; both = %q", pfA)
+	}
+}
+
+func TestSARIFFormatter_ContentFingerprint_StableAcrossWhitespace(t *testing.T) {
+	original := "if err != nil {\n    return err\n}\n"
+	reformatted := "if err != nil {\n\treturn err\n}\n\n" // tabs vs spaces, trailing blank line
+
+	a := formatAndParse(t, snippetSARIFLog("SEC001", "main.go", original, 10))
+	b := formatAndParse(t, snippetSARIFLog("SEC001", "main.go", reformatted, 10))
+
+	hashA := a.Runs[0].Results[0].Fingerprints["gavel/contentHash/v1"]
+	hashB := b.Runs[0].Results[0].Fingerprints["gavel/contentHash/v1"]
+	if hashA != hashB {
+		t.Errorf("contentHash should ignore whitespace-only reformatting; got %q vs %q", hashA, hashB)
+	}
+}
+
+func TestSARIFFormatter_ContentFingerprint_DiffersByRuleID(t *testing.T) {
+	snippet := "password := \"hunter2\"\n"
+	a := formatAndParse(t, snippetSARIFLog("SEC001", "config/db.go", snippet, 42))
+	b := formatAndParse(t, snippetSARIFLog("SEC002", "config/db.go", snippet, 42))
+
+	hashA := a.Runs[0].Results[0].Fingerprints["gavel/contentHash/v1"]
+	hashB := b.Runs[0].Results[0].Fingerprints["gavel/contentHash/v1"]
+	if hashA == hashB {
+		t.Errorf("contentHash should differ by rule ID; both = %q", hashA)
+	}
+}
+
+func TestSARIFFormatter_ContentFingerprint_OmittedWithoutSnippet(t *testing.T) {
+	// Default testSARIFLog() has a result without a snippet — the content
+	// fingerprint should be skipped entirely.
+	parsed := formatAndParse(t, testSARIFLog())
+	r := parsed.Runs[0].Results[0]
+	if _, ok := r.Fingerprints["gavel/contentHash/v1"]; ok {
+		t.Errorf("did not expect content fingerprint when snippet is absent; got %v", r.Fingerprints)
+	}
+	// PartialFingerprints should still be populated as before.
+	if _, ok := r.PartialFingerprints["primaryLocationLineHash"]; !ok {
+		t.Errorf("expected partialFingerprints to still be populated; got %v", r.PartialFingerprints)
+	}
+}
+
 func TestSARIFFormatter_HasPartialFingerprints(t *testing.T) {
 	f := &SARIFFormatter{}
 	result := &AnalysisOutput{SARIFLog: testSARIFLog()}

--- a/internal/sarif/sarif.go
+++ b/internal/sarif/sarif.go
@@ -95,6 +95,7 @@ type Result struct {
 	Level               string                 `json:"level"`
 	Message             Message                `json:"message"`
 	Locations           []Location             `json:"locations,omitempty"`
+	Fingerprints        map[string]string      `json:"fingerprints,omitempty"`
 	PartialFingerprints map[string]string      `json:"partialFingerprints,omitempty"`
 	Properties          map[string]interface{} `json:"properties,omitempty"`
 	Suppressions        []SARIFSuppression     `json:"suppressions,omitempty"`


### PR DESCRIPTION
The existing partialFingerprints["primaryLocationLineHash"] hashes ruleID
+ URI + startLine + message, so it breaks whenever unrelated edits move
findings to a new line. Add a new fingerprints["gavel/contentHash/v1"]
that hashes the rule ID together with the snippet text after normalizing
whitespace (trimmed lines, blank lines dropped). The hash now survives
line shifts and whitespace-only reformatting, giving consumers a stable
identity for deduplication and (eventually) regression tracking.

This is the first half of #80; baseline comparison via baselineGuid /
baselineState is intentionally deferred so this lands incrementally.

https://claude.ai/code/session_01Lh2MbbjKVkKAm1MkC4usra