### PR TITLE
feat(sarif): baseline comparison (baselineGuid/baselineState) across CLI, MCP, HTTP service

### DIFF
--- a/cmd/gavel/analyze.go
+++ b/cmd/gavel/analyze.go
@@ -267,7 +267,8 @@ func runAnalyze(cmd *cobra.Command, args []string) error {
 	// carries baselineState for downstream consumers to key off).
 	baselineNew, baselineUnchanged, baselineAbsent := 0, 0, 0
 	if flagBaseline != "" {
-		baselineLog, err := loadBaselineSARIF(ctx, flagBaseline, flagOutput)
+		baselineStore := store.NewFileStore(flagOutput)
+		baselineLog, err := store.LoadBaseline(ctx, baselineStore, flagBaseline)
 		if err != nil {
 			return fmt.Errorf("loading baseline %q: %w", flagBaseline, err)
 		}
@@ -379,26 +380,6 @@ func runAnalyze(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// loadBaselineSARIF resolves the --baseline argument to a SARIF log. If ref
-// points at an existing file it is read directly; otherwise ref is treated
-// as a store result ID under storeDir. This lets CI point at a downloaded
-// artifact (`--baseline ./prev/sarif.json`) while local workflows can just
-// reference the previous run by ID.
-func loadBaselineSARIF(ctx context.Context, ref, storeDir string) (*sarif.Log, error) {
-	if info, err := os.Stat(ref); err == nil && !info.IsDir() {
-		data, err := os.ReadFile(ref)
-		if err != nil {
-			return nil, err
-		}
-		var log sarif.Log
-		if err := json.Unmarshal(data, &log); err != nil {
-			return nil, fmt.Errorf("decoding baseline SARIF: %w", err)
-		}
-		return &log, nil
-	}
-	fs := store.NewFileStore(storeDir)
-	return fs.ReadSARIF(ctx, ref)
-}
 
 // uploadResultsToCache uploads analysis results to the remote cache server
 func uploadResultsToCache(ctx context.Context, cfg *config.Config, cacheURL string, artifacts []input.Artifact, results []sarif.Result) error {

--- a/cmd/gavel/analyze.go
+++ b/cmd/gavel/analyze.go
@@ -42,6 +42,7 @@ var (
 	flagPolicyDir   string
 	flagRulesDir    string
 	flagCacheServer string
+	flagBaseline    string
 )
 
 func init() {
@@ -58,6 +59,7 @@ func init() {
 	analyzeCmd.Flags().StringVar(&flagPolicyDir, "policies", ".gavel", "Directory containing policies.yaml")
 	analyzeCmd.Flags().StringVar(&flagRulesDir, "rules-dir", "", "Directory containing custom rule YAML files")
 	analyzeCmd.Flags().StringVar(&flagCacheServer, "cache-server", "", "Remote cache server URL to upload results (e.g., https://gavel.company.com)")
+	analyzeCmd.Flags().StringVar(&flagBaseline, "baseline", "", "Baseline SARIF to compare against (result ID from the store or a path to a sarif.json file). Each result gets a baselineState (new|unchanged|absent).")
 
 	rootCmd.AddCommand(analyzeCmd)
 }
@@ -254,6 +256,36 @@ func runAnalyze(cmd *cobra.Command, args []string) error {
 	// Assemble SARIF
 	sarifLog := sarif.Assemble(results, descriptors, inputScope, cfg.Persona)
 
+	// Stamp a stable automation guid so subsequent runs can reference this
+	// one via baselineGuid.
+	sarif.EnsureAutomationDetails(sarifLog)
+
+	// Baseline comparison: annotate every result with new|unchanged|absent
+	// relative to the baseline SARIF, if one was provided. This runs after
+	// SARIF assembly (so content fingerprints are populated) and before
+	// calibration/suppression (so they operate on a log that already
+	// carries baselineState for downstream consumers to key off).
+	baselineNew, baselineUnchanged, baselineAbsent := 0, 0, 0
+	if flagBaseline != "" {
+		baselineLog, err := loadBaselineSARIF(ctx, flagBaseline, flagOutput)
+		if err != nil {
+			return fmt.Errorf("loading baseline %q: %w", flagBaseline, err)
+		}
+		sarif.CompareBaseline(sarifLog, baselineLog)
+		if len(sarifLog.Runs) > 0 {
+			for _, r := range sarifLog.Runs[0].Results {
+				switch r.BaselineState {
+				case sarif.BaselineStateNew:
+					baselineNew++
+				case sarif.BaselineStateUnchanged:
+					baselineUnchanged++
+				case sarif.BaselineStateAbsent:
+					baselineAbsent++
+				}
+			}
+		}
+	}
+
 	// Calibration: apply threshold overrides
 	if thresholdOverrides != nil && len(sarifLog.Runs) > 0 {
 		suppressed := calibration.SuppressedResults(sarifLog.Runs[0].Results, thresholdOverrides)
@@ -327,16 +359,45 @@ func runAnalyze(cmd *cobra.Command, args []string) error {
 		findingCount = len(sarifLog.Runs[0].Results)
 	}
 	summary := map[string]interface{}{
-		"id":       id,
-		"findings": findingCount,
-		"scope":    inputScope,
+		"id":         id,
+		"findings":   findingCount,
+		"scope":      inputScope,
 		"persona":    cfg.Persona,
 		"suppressed": suppressedCount,
+	}
+	if flagBaseline != "" {
+		summary["baseline"] = map[string]interface{}{
+			"source":    flagBaseline,
+			"new":       baselineNew,
+			"unchanged": baselineUnchanged,
+			"absent":    baselineAbsent,
+		}
 	}
 	out, _ := json.MarshalIndent(summary, "", "  ")
 	fmt.Println(string(out))
 
 	return nil
+}
+
+// loadBaselineSARIF resolves the --baseline argument to a SARIF log. If ref
+// points at an existing file it is read directly; otherwise ref is treated
+// as a store result ID under storeDir. This lets CI point at a downloaded
+// artifact (`--baseline ./prev/sarif.json`) while local workflows can just
+// reference the previous run by ID.
+func loadBaselineSARIF(ctx context.Context, ref, storeDir string) (*sarif.Log, error) {
+	if info, err := os.Stat(ref); err == nil && !info.IsDir() {
+		data, err := os.ReadFile(ref)
+		if err != nil {
+			return nil, err
+		}
+		var log sarif.Log
+		if err := json.Unmarshal(data, &log); err != nil {
+			return nil, fmt.Errorf("decoding baseline SARIF: %w", err)
+		}
+		return &log, nil
+	}
+	fs := store.NewFileStore(storeDir)
+	return fs.ReadSARIF(ctx, ref)
 }
 
 // uploadResultsToCache uploads analysis results to the remote cache server

--- a/internal/evaluator/default.rego
+++ b/internal/evaluator/default.rego
@@ -9,17 +9,49 @@ _suppressed(result) if {
 	count(suppressions) > 0
 }
 
+# _is_pre_existing returns true for results that baseline comparison has
+# identified as already present in the baseline ("unchanged"). Gating
+# should ignore these so that a PR is not penalized for noise that
+# predates it.
+_is_pre_existing(result) if {
+	object.get(result, "baselineState", "") == "unchanged"
+}
+
+# _is_fixed returns true for results that baseline comparison has
+# identified as present in the baseline but absent from the current run
+# ("absent"). These represent findings that were fixed; gating should
+# ignore them so that a fix is not conflated with a regression.
+_is_fixed(result) if {
+	object.get(result, "baselineState", "") == "absent"
+}
+
+# unsuppressed_results is all results in the current run that do not
+# carry an explicit suppression. It is kept as a primitive that custom
+# policies can consume if they want to reason about the full
+# (post-suppression, pre-baseline-filter) set.
 unsuppressed_results contains result if {
 	some result in input.runs[0].results
 	not _suppressed(result)
 }
 
-decision := "reject" if {
+# actionable_results is the set that gating decisions should consider:
+# unsuppressed findings that are not pre-existing noise or already-fixed
+# findings. When analyze is run without --baseline no result carries a
+# baselineState, so _is_pre_existing/_is_fixed never match and this set
+# equals unsuppressed_results — preserving existing semantics for
+# callers that have not adopted baseline comparison.
+actionable_results contains result if {
 	some result in unsuppressed_results
+	not _is_pre_existing(result)
+	not _is_fixed(result)
+}
+
+decision := "reject" if {
+	some result in actionable_results
 	result.level == "error"
 	result.properties["gavel/confidence"] > 0.85
 }
 
 decision := "merge" if {
-	count(unsuppressed_results) == 0
+	count(actionable_results) == 0
 }

--- a/internal/evaluator/evaluator_test.go
+++ b/internal/evaluator/evaluator_test.go
@@ -117,3 +117,129 @@ decision := "reject" if {
 		t.Errorf("expected 'reject' from strict policy, got %q", verdict.Decision)
 	}
 }
+
+// TestEvaluator_BaselineFixedIgnored verifies that a result marked as
+// "absent" by baseline comparison (i.e. fixed — it was in the baseline
+// but is gone from the current run) does NOT trigger a reject, even
+// though it still carries level=error and high confidence.
+func TestEvaluator_BaselineFixedIgnored(t *testing.T) {
+	log := sarif.NewLog("gavel", "0.1.0")
+	log.Runs[0].Results = []sarif.Result{
+		{
+			RuleID:        "sql-injection",
+			Level:         "error",
+			Message:       sarif.Message{Text: "fixed in this PR"},
+			BaselineState: sarif.BaselineStateAbsent,
+			Properties:    map[string]interface{}{"gavel/confidence": 0.95},
+		},
+	}
+
+	e, err := NewEvaluator(context.Background(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	verdict, err := e.Evaluate(context.Background(), log)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// With only fixed findings, gating should merge (nothing actionable).
+	if verdict.Decision != "merge" {
+		t.Errorf("expected 'merge' when only finding is absent/fixed, got %q", verdict.Decision)
+	}
+}
+
+// TestEvaluator_BaselinePreExistingIgnored verifies that a result marked
+// "unchanged" (pre-existing noise) does NOT trigger a reject either.
+func TestEvaluator_BaselinePreExistingIgnored(t *testing.T) {
+	log := sarif.NewLog("gavel", "0.1.0")
+	log.Runs[0].Results = []sarif.Result{
+		{
+			RuleID:        "sql-injection",
+			Level:         "error",
+			Message:       sarif.Message{Text: "pre-existing"},
+			BaselineState: sarif.BaselineStateUnchanged,
+			Properties:    map[string]interface{}{"gavel/confidence": 0.95},
+		},
+	}
+
+	e, err := NewEvaluator(context.Background(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	verdict, err := e.Evaluate(context.Background(), log)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if verdict.Decision != "merge" {
+		t.Errorf("expected 'merge' when only finding is pre-existing, got %q", verdict.Decision)
+	}
+}
+
+// TestEvaluator_BaselineNewStillRejects verifies that a result marked
+// "new" by baseline comparison still triggers a reject when it crosses
+// the severity/confidence threshold — this is the regression-gating
+// case that baseline tracking is supposed to enable.
+func TestEvaluator_BaselineNewStillRejects(t *testing.T) {
+	log := sarif.NewLog("gavel", "0.1.0")
+	log.Runs[0].Results = []sarif.Result{
+		{
+			RuleID:        "sql-injection",
+			Level:         "error",
+			Message:       sarif.Message{Text: "regression"},
+			BaselineState: sarif.BaselineStateNew,
+			Properties:    map[string]interface{}{"gavel/confidence": 0.95},
+		},
+	}
+
+	e, err := NewEvaluator(context.Background(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	verdict, err := e.Evaluate(context.Background(), log)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if verdict.Decision != "reject" {
+		t.Errorf("expected 'reject' for new high-severity finding, got %q", verdict.Decision)
+	}
+}
+
+// TestEvaluator_BaselineMixedNewAndPreExisting exercises the whole
+// baseline flow: a PR that introduced one new high-severity finding on
+// top of an existing one should still reject, and the reject decision
+// must key off the new finding, not the pre-existing one.
+func TestEvaluator_BaselineMixedNewAndPreExisting(t *testing.T) {
+	log := sarif.NewLog("gavel", "0.1.0")
+	log.Runs[0].Results = []sarif.Result{
+		{
+			RuleID:        "sql-injection",
+			Level:         "error",
+			Message:       sarif.Message{Text: "pre-existing"},
+			BaselineState: sarif.BaselineStateUnchanged,
+			Properties:    map[string]interface{}{"gavel/confidence": 0.95},
+		},
+		{
+			RuleID:        "path-traversal",
+			Level:         "error",
+			Message:       sarif.Message{Text: "regression"},
+			BaselineState: sarif.BaselineStateNew,
+			Properties:    map[string]interface{}{"gavel/confidence": 0.9},
+		},
+	}
+
+	e, err := NewEvaluator(context.Background(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	verdict, err := e.Evaluate(context.Background(), log)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if verdict.Decision != "reject" {
+		t.Errorf("expected 'reject' when PR adds a new regression on top of pre-existing noise, got %q", verdict.Decision)
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -90,6 +90,9 @@ func analyzeFileTool() mcp.Tool {
 		mcp.WithString("persona",
 			mcp.Description("Analysis persona: code-reviewer, architect, or security"),
 		),
+		mcp.WithString("baseline",
+			mcp.Description("Optional baseline to compare against: a stored result ID or a path to a sarif.json file. Each finding gets a baselineState (new|unchanged|absent)."),
+		),
 	)
 }
 
@@ -102,6 +105,9 @@ func analyzeDirectoryTool() mcp.Tool {
 		),
 		mcp.WithString("persona",
 			mcp.Description("Analysis persona: code-reviewer, architect, or security"),
+		),
+		mcp.WithString("baseline",
+			mcp.Description("Optional baseline to compare against: a stored result ID or a path to a sarif.json file. Each finding gets a baselineState (new|unchanged|absent)."),
 		),
 	)
 }
@@ -187,6 +193,9 @@ func analyzeDiffTool() mcp.Tool {
 		mcp.WithString("persona",
 			mcp.Description("Analysis persona: code-reviewer, architect, or security"),
 		),
+		mcp.WithString("baseline",
+			mcp.Description("Optional baseline to compare against: a stored result ID or a path to a sarif.json file. Each finding gets a baselineState (new|unchanged|absent)."),
+		),
 	)
 }
 
@@ -239,6 +248,48 @@ func architectureReviewPrompt() mcp.Prompt {
 	)
 }
 
+// baselineCounts summarizes how many results fell into each baselineState
+// bucket after CompareBaseline was applied. An empty value means no
+// baseline comparison was performed.
+type baselineCounts struct {
+	Source    string `json:"source"`
+	New       int    `json:"new"`
+	Unchanged int    `json:"unchanged"`
+	Absent    int    `json:"absent"`
+}
+
+// applyBaseline stamps automation details onto sarifLog and, when the
+// `baseline` tool parameter is set, loads that baseline and annotates
+// each result with a baselineState. Returns the bucket counts so the
+// handler can include them in its summary, or a CallToolResult error if
+// the baseline failed to load.
+func (h *handlers) applyBaseline(ctx context.Context, sarifLog *sarif.Log, baseline string) (baselineCounts, *mcp.CallToolResult) {
+	sarif.EnsureAutomationDetails(sarifLog)
+	if baseline == "" {
+		return baselineCounts{}, nil
+	}
+	baselineLog, err := store.LoadBaseline(ctx, h.cfg.Store, baseline)
+	if err != nil {
+		return baselineCounts{}, mcp.NewToolResultError(fmt.Sprintf("loading baseline %q: %v", baseline, err))
+	}
+	sarif.CompareBaseline(sarifLog, baselineLog)
+
+	counts := baselineCounts{Source: baseline}
+	if len(sarifLog.Runs) > 0 {
+		for _, r := range sarifLog.Runs[0].Results {
+			switch r.BaselineState {
+			case sarif.BaselineStateNew:
+				counts.New++
+			case sarif.BaselineStateUnchanged:
+				counts.Unchanged++
+			case sarif.BaselineStateAbsent:
+				counts.Absent++
+			}
+		}
+	}
+	return counts, nil
+}
+
 // --- Tool handlers ---
 
 func (h *handlers) handleAnalyzeFile(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -256,6 +307,8 @@ func (h *handlers) handleAnalyzeFile(ctx context.Context, request mcp.CallToolRe
 		persona = "code-reviewer"
 	}
 
+	baseline := request.GetString("baseline", "")
+
 	// Read the file
 	content, err := os.ReadFile(path)
 	if err != nil {
@@ -271,6 +324,11 @@ func (h *handlers) handleAnalyzeFile(ctx context.Context, request mcp.CallToolRe
 	// Build SARIF and store so judge can evaluate later
 	rules := buildRules(h.cfg.Config.Policies)
 	sarifLog := sarif.Assemble(results, rules, "file", persona)
+
+	baselineSummary, errResult := h.applyBaseline(ctx, sarifLog, baseline)
+	if errResult != nil {
+		return errResult, nil
+	}
 
 	supps, loadErr := suppression.Load(h.rootDir())
 	if loadErr != nil {
@@ -289,6 +347,9 @@ func (h *handlers) handleAnalyzeFile(ctx context.Context, request mcp.CallToolRe
 		"files":    1,
 		"persona":  persona,
 		"path":     path,
+	}
+	if baseline != "" {
+		summary["baseline"] = baselineSummary
 	}
 	out, err := json.MarshalIndent(summary, "", "  ")
 	if err != nil {
@@ -313,6 +374,8 @@ func (h *handlers) handleAnalyzeDirectory(ctx context.Context, request mcp.CallT
 		persona = "code-reviewer"
 	}
 
+	baseline := request.GetString("baseline", "")
+
 	// Read directory
 	handler := input.NewHandler()
 	artifacts, err := handler.ReadDirectory(dir)
@@ -334,6 +397,11 @@ func (h *handlers) handleAnalyzeDirectory(ctx context.Context, request mcp.CallT
 	rules := buildRules(h.cfg.Config.Policies)
 	sarifLog := sarif.Assemble(results, rules, "directory", persona)
 
+	baselineSummary, errResult := h.applyBaseline(ctx, sarifLog, baseline)
+	if errResult != nil {
+		return errResult, nil
+	}
+
 	supps, loadErr := suppression.Load(h.rootDir())
 	if loadErr != nil {
 		slog.Warn("failed to load suppressions", "err", loadErr)
@@ -350,6 +418,9 @@ func (h *handlers) handleAnalyzeDirectory(ctx context.Context, request mcp.CallT
 		"findings": len(results),
 		"files":    len(artifacts),
 		"persona":  persona,
+	}
+	if baseline != "" {
+		summary["baseline"] = baselineSummary
 	}
 	out, err := json.MarshalIndent(summary, "", "  ")
 	if err != nil {
@@ -488,6 +559,8 @@ func (h *handlers) handleAnalyzeDiff(ctx context.Context, request mcp.CallToolRe
 		persona = "code-reviewer"
 	}
 
+	baseline := request.GetString("baseline", "")
+
 	// Read the full file
 	content, err := os.ReadFile(path)
 	if err != nil {
@@ -574,6 +647,11 @@ func (h *handlers) handleAnalyzeDiff(ctx context.Context, request mcp.CallToolRe
 	rules := buildRules(h.cfg.Config.Policies)
 	sarifLog := sarif.Assemble(allResults, rules, "diff", persona)
 
+	baselineSummary, errResult := h.applyBaseline(ctx, sarifLog, baseline)
+	if errResult != nil {
+		return errResult, nil
+	}
+
 	supps, loadErr := suppression.Load(h.rootDir())
 	if loadErr != nil {
 		slog.Warn("failed to load suppressions", "err", loadErr)
@@ -592,6 +670,9 @@ func (h *handlers) handleAnalyzeDiff(ctx context.Context, request mcp.CallToolRe
 		"persona":       persona,
 		"changed_start": changedStart,
 		"changed_end":   changedEnd,
+	}
+	if baseline != "" {
+		summary["baseline"] = baselineSummary
 	}
 	out, err := json.MarshalIndent(summary, "", "  ")
 	if err != nil {

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -1003,3 +1003,142 @@ func TestExtractChangedLines(t *testing.T) {
 		})
 	}
 }
+
+// TestApplyBaseline_StampsAutomationAndCompares is a unit test for the
+// shared applyBaseline helper used by every MCP analyze_* handler. It
+// seeds the store with a baseline run, calls applyBaseline, and asserts
+// that the current log is linked to the baseline GUID and that its
+// results carry baselineState buckets.
+func TestApplyBaseline_StampsAutomationAndCompares(t *testing.T) {
+	dir := t.TempDir()
+	fs := store.NewFileStore(dir)
+	ctx := context.Background()
+
+	// Seed a baseline SARIF in the store with one error-level finding
+	// whose content will match a finding in the current run.
+	baselineLog := sarif.NewLog("gavel", "0.1.0")
+	baselineLog.Runs[0].AutomationDetails = &sarif.RunAutomationDetails{Guid: "prev-run-guid"}
+	baselineLog.Runs[0].Results = []sarif.Result{
+		{
+			RuleID:  "bug-detection",
+			Level:   "error",
+			Message: sarif.Message{Text: "pre-existing"},
+			Locations: []sarif.Location{{PhysicalLocation: sarif.PhysicalLocation{
+				ArtifactLocation: sarif.ArtifactLocation{URI: "a.go"},
+				Region: sarif.Region{
+					StartLine: 10, EndLine: 10,
+					Snippet: &sarif.ArtifactContent{Text: "password := \"hunter2\"\n"},
+				},
+			}}},
+		},
+	}
+	sarif.SetContentFingerprint(&baselineLog.Runs[0].Results[0])
+	baselineID, err := fs.WriteSARIF(ctx, baselineLog)
+	if err != nil {
+		t.Fatalf("seeding baseline: %v", err)
+	}
+
+	// Build a current log that duplicates the baseline's finding
+	// (should come out unchanged) and adds a new one.
+	current := sarif.NewLog("gavel", "0.1.0")
+	current.Runs[0].Results = []sarif.Result{
+		{
+			RuleID:  "bug-detection",
+			Level:   "error",
+			Message: sarif.Message{Text: "same"},
+			Locations: []sarif.Location{{PhysicalLocation: sarif.PhysicalLocation{
+				ArtifactLocation: sarif.ArtifactLocation{URI: "a.go"},
+				Region: sarif.Region{
+					StartLine: 42, EndLine: 42,
+					Snippet: &sarif.ArtifactContent{Text: "password := \"hunter2\"\n"},
+				},
+			}}},
+		},
+		{
+			RuleID:  "bug-detection",
+			Level:   "warning",
+			Message: sarif.Message{Text: "new"},
+			Locations: []sarif.Location{{PhysicalLocation: sarif.PhysicalLocation{
+				ArtifactLocation: sarif.ArtifactLocation{URI: "b.go"},
+				Region: sarif.Region{
+					StartLine: 1, EndLine: 1,
+					Snippet: &sarif.ArtifactContent{Text: "os.Remove(userPath)\n"},
+				},
+			}}},
+		},
+	}
+	for i := range current.Runs[0].Results {
+		sarif.SetContentFingerprint(&current.Runs[0].Results[i])
+	}
+
+	h := newTestHandlers(t, testConfig(), fs, dir)
+
+	counts, errResult := h.applyBaseline(ctx, current, baselineID)
+	if errResult != nil {
+		t.Fatalf("applyBaseline returned error result: %v", errResult.Content)
+	}
+
+	if current.Runs[0].AutomationDetails == nil || current.Runs[0].AutomationDetails.Guid == "" {
+		t.Error("expected AutomationDetails.Guid to be stamped on the current run")
+	}
+	if current.Runs[0].BaselineGuid != "prev-run-guid" {
+		t.Errorf("BaselineGuid = %q, want %q", current.Runs[0].BaselineGuid, "prev-run-guid")
+	}
+
+	if counts.New != 1 {
+		t.Errorf("counts.New = %d, want 1", counts.New)
+	}
+	if counts.Unchanged != 1 {
+		t.Errorf("counts.Unchanged = %d, want 1", counts.Unchanged)
+	}
+	if counts.Absent != 0 {
+		t.Errorf("counts.Absent = %d, want 0", counts.Absent)
+	}
+	if counts.Source != baselineID {
+		t.Errorf("counts.Source = %q, want %q", counts.Source, baselineID)
+	}
+}
+
+// TestApplyBaseline_NoBaselineStillStampsGUID verifies that calling
+// applyBaseline with an empty baseline ref stamps automation details
+// (so the next run can chain back to this one) but performs no
+// comparison.
+func TestApplyBaseline_NoBaselineStillStampsGUID(t *testing.T) {
+	dir := t.TempDir()
+	fs := store.NewFileStore(dir)
+
+	current := sarif.NewLog("gavel", "0.1.0")
+	h := newTestHandlers(t, testConfig(), fs, dir)
+
+	counts, errResult := h.applyBaseline(context.Background(), current, "")
+	if errResult != nil {
+		t.Fatalf("unexpected error result: %v", errResult.Content)
+	}
+	if counts != (baselineCounts{}) {
+		t.Errorf("expected zero counts when no baseline, got %+v", counts)
+	}
+	if current.Runs[0].AutomationDetails == nil || current.Runs[0].AutomationDetails.Guid == "" {
+		t.Error("expected AutomationDetails.Guid to be stamped even without a baseline")
+	}
+	if current.Runs[0].BaselineGuid != "" {
+		t.Errorf("expected empty BaselineGuid, got %q", current.Runs[0].BaselineGuid)
+	}
+}
+
+// TestApplyBaseline_MissingBaselineIDReturnsError verifies that a
+// missing baseline ID surfaces an MCP error result rather than silently
+// succeeding.
+func TestApplyBaseline_MissingBaselineIDReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	fs := store.NewFileStore(dir)
+	current := sarif.NewLog("gavel", "0.1.0")
+
+	h := newTestHandlers(t, testConfig(), fs, dir)
+	_, errResult := h.applyBaseline(context.Background(), current, "does-not-exist")
+	if errResult == nil {
+		t.Fatal("expected error result for missing baseline id")
+	}
+	if !errResult.IsError {
+		t.Error("expected IsError=true on returned result")
+	}
+}

--- a/internal/output/sarif.go
+++ b/internal/output/sarif.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/chris-regnier/gavel/internal/sarif"
 )
@@ -69,38 +68,25 @@ func enrichResult(r *sarif.Result) {
 		r.Properties = make(map[string]any)
 	}
 
-	// Extract location info once.
+	// Compute partial fingerprint from ruleID, URI, startLine, and message.
+	// This is line-positional and breaks when lines shift.
 	uri := ""
 	startLine := 0
-	var snippet string
 	if len(r.Locations) > 0 {
 		loc := r.Locations[0]
 		uri = loc.PhysicalLocation.ArtifactLocation.URI
 		startLine = loc.PhysicalLocation.Region.StartLine
-		if loc.PhysicalLocation.Region.Snippet != nil {
-			snippet = loc.PhysicalLocation.Region.Snippet.Text
-		}
 	}
-
-	// Compute partial fingerprint from ruleID, URI, startLine, and message.
-	// This is line-positional and breaks when lines shift.
 	fingerprintInput := fmt.Sprintf("%s|%s|%d|%s", r.RuleID, uri, startLine, r.Message.Text)
 	hash := sha256.Sum256([]byte(fingerprintInput))
 	r.PartialFingerprints["primaryLocationLineHash"] = fmt.Sprintf("%x", hash[:16]) // first 32 hex chars (16 bytes)
 
-	// Compute content-based fingerprint that survives line shifts and
-	// whitespace-only reformatting. We hash the rule ID together with the
-	// snippet text after normalizing whitespace (trim each line, drop blank
-	// lines). When no snippet is available we skip the content fingerprint;
-	// the partialFingerprint above still provides a positional identity.
-	if normalized := normalizeSnippet(snippet); normalized != "" {
-		if r.Fingerprints == nil {
-			r.Fingerprints = make(map[string]string)
-		}
-		contentInput := r.RuleID + "\n" + normalized
-		contentHash := sha256.Sum256([]byte(contentInput))
-		r.Fingerprints["gavel/contentHash/v1"] = fmt.Sprintf("%x", contentHash[:16])
-	}
+	// Populate the content-based fingerprint (stable across line shifts and
+	// whitespace-only reformatting). Assemble() already calls this during
+	// SARIF construction; repeat it here so logs built by callers that skip
+	// Assemble — or that reach the formatter before fingerprint population —
+	// still get a content fingerprint.
+	sarif.SetContentFingerprint(r)
 
 	// Map level to security-severity score.
 	r.Properties["security-severity"] = securitySeverity(r.Level)
@@ -108,27 +94,6 @@ func enrichResult(r *sarif.Result) {
 	// Map tier to precision.
 	tier, _ := r.Properties["gavel/tier"].(string)
 	r.Properties["precision"] = tierPrecision(tier)
-}
-
-// normalizeSnippet returns a whitespace-normalized form of a code snippet
-// suitable for content-based fingerprinting. Each line is trimmed of leading
-// and trailing whitespace and blank lines are dropped, so reformatting that
-// only changes indentation or blank-line padding produces the same hash.
-// Returns "" if the snippet contains no non-whitespace content.
-func normalizeSnippet(s string) string {
-	if s == "" {
-		return ""
-	}
-	lines := strings.Split(s, "\n")
-	out := make([]string, 0, len(lines))
-	for _, line := range lines {
-		trimmed := strings.TrimSpace(line)
-		if trimmed == "" {
-			continue
-		}
-		out = append(out, trimmed)
-	}
-	return strings.Join(out, "\n")
 }
 
 // securitySeverity maps SARIF levels to GitHub Code Scanning security-severity scores.

--- a/internal/sarif/assembler.go
+++ b/internal/sarif/assembler.go
@@ -3,6 +3,9 @@ package sarif
 // Assemble creates a SARIF log from analysis results, deduplicating overlapping findings.
 func Assemble(results []Result, rules []ReportingDescriptor, inputScope, persona string) *Log {
 	deduped := dedup(results)
+	for i := range deduped {
+		SetContentFingerprint(&deduped[i])
+	}
 
 	log := NewLog("gavel", "0.1.0")
 	log.Runs[0].Tool.Driver.Rules = rules

--- a/internal/sarif/assembler_test.go
+++ b/internal/sarif/assembler_test.go
@@ -174,3 +174,23 @@ func TestAssemble_NoTaxonomiesWhenNoRelationships(t *testing.T) {
 		t.Errorf("expected nil taxonomies, got %+v", log.Runs[0].Taxonomies)
 	}
 }
+
+func TestAssemble_PopulatesContentFingerprints(t *testing.T) {
+	results := []Result{
+		{
+			RuleID: "SEC001", Level: "error", Message: Message{Text: "finding"},
+			Locations: []Location{{PhysicalLocation: PhysicalLocation{
+				ArtifactLocation: ArtifactLocation{URI: "a.go"},
+				Region: Region{
+					StartLine: 10, EndLine: 10,
+					Snippet: &ArtifactContent{Text: "password := \"hunter2\"\n"},
+				},
+			}}},
+		},
+	}
+	log := Assemble(results, nil, "files", "code-reviewer")
+	r := log.Runs[0].Results[0]
+	if _, ok := r.Fingerprints[ContentFingerprintV1]; !ok {
+		t.Errorf("expected Assemble to populate %q; fingerprints=%v", ContentFingerprintV1, r.Fingerprints)
+	}
+}

--- a/internal/sarif/baseline.go
+++ b/internal/sarif/baseline.go
@@ -1,0 +1,132 @@
+package sarif
+
+import (
+	"crypto/rand"
+	"fmt"
+)
+
+// BaselineState values per SARIF 2.1.0 §3.27.19.
+const (
+	BaselineStateNew       = "new"
+	BaselineStateUnchanged = "unchanged"
+	BaselineStateUpdated   = "updated"
+	BaselineStateAbsent    = "absent"
+)
+
+// CompareBaseline annotates each result in current with a baselineState
+// relative to baseline and links current to baseline via baselineGuid.
+//
+// Matching uses the content-based fingerprint (ContentFingerprintV1):
+//
+//   - unchanged: a current result whose fingerprint exists in baseline
+//   - new:       a current result whose fingerprint is absent from baseline
+//   - absent:    a baseline result whose fingerprint is absent from current,
+//     appended to current.Runs[0].Results so downstream consumers
+//     (dashboards, gating rules) can see what was fixed
+//
+// Results in current that lack a content fingerprint are left untouched:
+// without a stable identifier we cannot place them on either side of the
+// comparison. CompareBaseline is a no-op if either log is nil or has no
+// runs.
+func CompareBaseline(current, baseline *Log) {
+	if current == nil || baseline == nil {
+		return
+	}
+	if len(current.Runs) == 0 || len(baseline.Runs) == 0 {
+		return
+	}
+	curRun := &current.Runs[0]
+	baseRun := &baseline.Runs[0]
+
+	// Link to the baseline run's automation guid, if present, so downstream
+	// consumers can walk the chain of runs.
+	if baseRun.AutomationDetails != nil && baseRun.AutomationDetails.Guid != "" {
+		curRun.BaselineGuid = baseRun.AutomationDetails.Guid
+	}
+
+	// Index the baseline by content fingerprint -> the baseline result, so
+	// we can both detect matches and surface any that went absent.
+	baselineByFingerprint := make(map[string]int, len(baseRun.Results))
+	for i, r := range baseRun.Results {
+		fp := contentFingerprint(r)
+		if fp == "" {
+			continue
+		}
+		// Keep the first occurrence; dedup should make this irrelevant in
+		// practice and the remaining duplicates still get indexed for the
+		// "seen" check below.
+		if _, exists := baselineByFingerprint[fp]; !exists {
+			baselineByFingerprint[fp] = i
+		}
+	}
+
+	// Walk current results: unchanged if fingerprint appears in baseline,
+	// new otherwise. Fingerprintless results are skipped.
+	seen := make(map[string]bool, len(curRun.Results))
+	for i := range curRun.Results {
+		r := &curRun.Results[i]
+		fp := contentFingerprint(*r)
+		if fp == "" {
+			continue
+		}
+		if _, ok := baselineByFingerprint[fp]; ok {
+			r.BaselineState = BaselineStateUnchanged
+		} else {
+			r.BaselineState = BaselineStateNew
+		}
+		seen[fp] = true
+	}
+
+	// Append absent findings: anything in baseline whose fingerprint did
+	// not reappear in current. We copy the baseline result so mutations on
+	// current don't leak back into the caller's baseline log.
+	for _, r := range baseRun.Results {
+		fp := contentFingerprint(r)
+		if fp == "" || seen[fp] {
+			continue
+		}
+		absent := r
+		absent.BaselineState = BaselineStateAbsent
+		curRun.Results = append(curRun.Results, absent)
+	}
+}
+
+// EnsureAutomationDetails sets a fresh automation GUID on the run if it is
+// missing. Call this before storing a new SARIF log so subsequent runs can
+// reference it via BaselineGuid. Existing GUIDs are left alone so callers
+// that assign their own identifier (e.g. CI run id) are respected.
+func EnsureAutomationDetails(log *Log) {
+	if log == nil || len(log.Runs) == 0 {
+		return
+	}
+	run := &log.Runs[0]
+	if run.AutomationDetails == nil {
+		run.AutomationDetails = &RunAutomationDetails{}
+	}
+	if run.AutomationDetails.Guid == "" {
+		run.AutomationDetails.Guid = newGUID()
+	}
+}
+
+// contentFingerprint returns the content-based fingerprint for r, or "" if
+// none is set.
+func contentFingerprint(r Result) string {
+	if r.Fingerprints == nil {
+		return ""
+	}
+	return r.Fingerprints[ContentFingerprintV1]
+}
+
+// newGUID returns a random RFC 4122 version 4 UUID string. Falls back to a
+// plain hex string if the OS RNG fails (crypto/rand effectively never
+// does, so the fallback is defensive).
+func newGUID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return fmt.Sprintf("%032x", b[:])
+	}
+	// Set version (4) and variant (RFC 4122) bits.
+	b[6] = (b[6] & 0x0f) | 0x40
+	b[8] = (b[8] & 0x3f) | 0x80
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:])
+}

--- a/internal/sarif/baseline_test.go
+++ b/internal/sarif/baseline_test.go
@@ -1,0 +1,207 @@
+package sarif
+
+import (
+	"regexp"
+	"testing"
+)
+
+// makeResult returns a Result with a snippet populated, suitable for
+// fingerprinting via SetContentFingerprint.
+func makeResult(ruleID, uri, snippet string, startLine int) Result {
+	return Result{
+		RuleID:  ruleID,
+		Level:   "warning",
+		Message: Message{Text: "test"},
+		Locations: []Location{{PhysicalLocation: PhysicalLocation{
+			ArtifactLocation: ArtifactLocation{URI: uri},
+			Region: Region{
+				StartLine: startLine,
+				EndLine:   startLine,
+				Snippet:   &ArtifactContent{Text: snippet},
+			},
+		}}},
+	}
+}
+
+// makeLog wraps a list of results into a Log, running SetContentFingerprint
+// on each so they can participate in baseline comparison.
+func makeLog(results ...Result) *Log {
+	for i := range results {
+		SetContentFingerprint(&results[i])
+	}
+	return &Log{
+		Runs: []Run{{Results: results}},
+	}
+}
+
+func TestCompareBaseline_MixedStates(t *testing.T) {
+	baseline := makeLog(
+		makeResult("SEC001", "a.go", "password := \"hunter2\"\n", 10),
+		makeResult("SEC002", "b.go", "eval(userInput)\n", 20), // fixed in current
+	)
+	// Current keeps SEC001 (moved to a new line) and introduces SEC003.
+	current := makeLog(
+		makeResult("SEC001", "a.go", "password := \"hunter2\"\n", 42),
+		makeResult("SEC003", "c.go", "os.Remove(userPath)\n", 5),
+	)
+
+	CompareBaseline(current, baseline)
+
+	if got := len(current.Runs[0].Results); got != 3 {
+		t.Fatalf("expected 3 results after baseline (2 current + 1 absent), got %d", got)
+	}
+
+	states := map[string]string{}
+	for _, r := range current.Runs[0].Results {
+		states[r.RuleID] = r.BaselineState
+	}
+	if states["SEC001"] != BaselineStateUnchanged {
+		t.Errorf("SEC001 baselineState = %q, want unchanged (content fingerprint should survive line shift)", states["SEC001"])
+	}
+	if states["SEC003"] != BaselineStateNew {
+		t.Errorf("SEC003 baselineState = %q, want new", states["SEC003"])
+	}
+	if states["SEC002"] != BaselineStateAbsent {
+		t.Errorf("SEC002 baselineState = %q, want absent", states["SEC002"])
+	}
+}
+
+func TestCompareBaseline_AllNew(t *testing.T) {
+	baseline := makeLog() // no results
+	current := makeLog(
+		makeResult("SEC001", "a.go", "x := 1\n", 1),
+		makeResult("SEC002", "b.go", "y := 2\n", 1),
+	)
+
+	CompareBaseline(current, baseline)
+
+	for _, r := range current.Runs[0].Results {
+		if r.BaselineState != BaselineStateNew {
+			t.Errorf("%s baselineState = %q, want new", r.RuleID, r.BaselineState)
+		}
+	}
+}
+
+func TestCompareBaseline_AllUnchanged(t *testing.T) {
+	shared := []Result{
+		makeResult("SEC001", "a.go", "x := 1\n", 1),
+		makeResult("SEC002", "b.go", "y := 2\n", 1),
+	}
+	baseline := makeLog(shared[0], shared[1])
+	current := makeLog(shared[0], shared[1])
+
+	CompareBaseline(current, baseline)
+
+	if got := len(current.Runs[0].Results); got != 2 {
+		t.Fatalf("expected 2 results, got %d", got)
+	}
+	for _, r := range current.Runs[0].Results {
+		if r.BaselineState != BaselineStateUnchanged {
+			t.Errorf("%s baselineState = %q, want unchanged", r.RuleID, r.BaselineState)
+		}
+	}
+}
+
+func TestCompareBaseline_CopiesBaselineGuid(t *testing.T) {
+	baseline := makeLog(makeResult("SEC001", "a.go", "x\n", 1))
+	baseline.Runs[0].AutomationDetails = &RunAutomationDetails{
+		Guid: "baseline-guid-42",
+	}
+	current := makeLog(makeResult("SEC001", "a.go", "x\n", 1))
+
+	CompareBaseline(current, baseline)
+
+	if got := current.Runs[0].BaselineGuid; got != "baseline-guid-42" {
+		t.Errorf("BaselineGuid = %q, want %q", got, "baseline-guid-42")
+	}
+}
+
+func TestCompareBaseline_SkipsResultsWithoutFingerprint(t *testing.T) {
+	// A result without a snippet gets no content fingerprint, so we can't
+	// place it on either side of the comparison — it should be left alone.
+	noSnippet := Result{
+		RuleID:  "SEC001",
+		Message: Message{Text: "no snippet"},
+		Locations: []Location{{PhysicalLocation: PhysicalLocation{
+			ArtifactLocation: ArtifactLocation{URI: "a.go"},
+			Region:           Region{StartLine: 1, EndLine: 1},
+		}}},
+	}
+	current := &Log{Runs: []Run{{Results: []Result{noSnippet}}}}
+	baseline := makeLog(makeResult("SEC001", "a.go", "x\n", 1))
+
+	CompareBaseline(current, baseline)
+
+	if got := current.Runs[0].Results[0].BaselineState; got != "" {
+		t.Errorf("expected empty baselineState for fingerprintless result, got %q", got)
+	}
+	// The baseline result still went absent (not seen in current).
+	if got := len(current.Runs[0].Results); got != 2 {
+		t.Errorf("expected 2 results (1 skipped + 1 absent), got %d", got)
+	}
+}
+
+func TestCompareBaseline_NilLogsAreNoop(t *testing.T) {
+	current := makeLog(makeResult("SEC001", "a.go", "x\n", 1))
+	CompareBaseline(current, nil)
+	if r := current.Runs[0].Results[0]; r.BaselineState != "" {
+		t.Errorf("expected no mutation when baseline is nil, got baselineState=%q", r.BaselineState)
+	}
+
+	// Empty runs: also a no-op.
+	CompareBaseline(&Log{}, &Log{})
+}
+
+func TestCompareBaseline_DoesNotMutateBaseline(t *testing.T) {
+	baseline := makeLog(makeResult("SEC002", "b.go", "fixed\n", 1))
+	current := makeLog(makeResult("SEC001", "a.go", "new\n", 1))
+
+	CompareBaseline(current, baseline)
+
+	// The baseline log must not be mutated — consumers may reuse it.
+	if got := baseline.Runs[0].Results[0].BaselineState; got != "" {
+		t.Errorf("baseline result should be untouched, got baselineState=%q", got)
+	}
+	if got := baseline.Runs[0].BaselineGuid; got != "" {
+		t.Errorf("baseline run should be untouched, got baselineGuid=%q", got)
+	}
+}
+
+func TestEnsureAutomationDetails_AssignsGUID(t *testing.T) {
+	log := makeLog()
+	EnsureAutomationDetails(log)
+
+	if log.Runs[0].AutomationDetails == nil {
+		t.Fatal("expected AutomationDetails to be set")
+	}
+	guid := log.Runs[0].AutomationDetails.Guid
+	if guid == "" {
+		t.Fatal("expected guid to be assigned")
+	}
+	// Looks like a v4 UUID: 8-4-4-4-12 lowercase hex with the version
+	// nibble set to 4 and the RFC 4122 variant bits set.
+	uuidRe := regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
+	if !uuidRe.MatchString(guid) {
+		t.Errorf("guid %q does not look like a v4 UUID", guid)
+	}
+}
+
+func TestEnsureAutomationDetails_PreservesExisting(t *testing.T) {
+	log := makeLog()
+	log.Runs[0].AutomationDetails = &RunAutomationDetails{Guid: "caller-assigned"}
+	EnsureAutomationDetails(log)
+
+	if got := log.Runs[0].AutomationDetails.Guid; got != "caller-assigned" {
+		t.Errorf("guid = %q, want caller-assigned to be preserved", got)
+	}
+}
+
+func TestEnsureAutomationDetails_UniquePerCall(t *testing.T) {
+	a := makeLog()
+	b := makeLog()
+	EnsureAutomationDetails(a)
+	EnsureAutomationDetails(b)
+	if a.Runs[0].AutomationDetails.Guid == b.Runs[0].AutomationDetails.Guid {
+		t.Error("expected distinct guids for separate calls")
+	}
+}

--- a/internal/sarif/builder.go
+++ b/internal/sarif/builder.go
@@ -85,6 +85,12 @@ func (a *Assembler) Build() *Log {
 	// Deduplicate results
 	deduped := dedup(a.results)
 
+	// Populate content-based fingerprints on every result so the SARIF log
+	// carries stable identifiers for baseline comparison downstream.
+	for i := range deduped {
+		SetContentFingerprint(&deduped[i])
+	}
+
 	// Add cache metadata to each result if configured
 	if a.cacheMetadata != nil {
 		cacheKey := computeCacheKey(a.cacheMetadata)

--- a/internal/sarif/fingerprint.go
+++ b/internal/sarif/fingerprint.go
@@ -1,0 +1,60 @@
+package sarif
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"strings"
+)
+
+// ContentFingerprintV1 is the key under which Gavel stores its
+// content-based SARIF fingerprint. Unlike the positional partialFingerprint
+// "primaryLocationLineHash", this fingerprint depends only on the rule ID
+// and the snippet text (with whitespace normalized), so it remains stable
+// across line shifts and whitespace-only reformatting.
+const ContentFingerprintV1 = "gavel/contentHash/v1"
+
+// SetContentFingerprint computes the content-based fingerprint for a result
+// and writes it into r.Fingerprints[ContentFingerprintV1]. If the result has
+// no snippet (or the snippet contains no non-whitespace content), no
+// fingerprint is set and r is left unchanged. Calling this function on a
+// result that already has a content fingerprint overwrites the existing
+// value; it is idempotent when inputs are unchanged.
+func SetContentFingerprint(r *Result) {
+	if r == nil || len(r.Locations) == 0 {
+		return
+	}
+	snippet := r.Locations[0].PhysicalLocation.Region.Snippet
+	if snippet == nil {
+		return
+	}
+	normalized := normalizeSnippet(snippet.Text)
+	if normalized == "" {
+		return
+	}
+	if r.Fingerprints == nil {
+		r.Fingerprints = make(map[string]string)
+	}
+	input := r.RuleID + "\n" + normalized
+	hash := sha256.Sum256([]byte(input))
+	r.Fingerprints[ContentFingerprintV1] = fmt.Sprintf("%x", hash[:16])
+}
+
+// normalizeSnippet returns a whitespace-normalized form of a code snippet
+// suitable for content-based fingerprinting. Each line is trimmed of leading
+// and trailing whitespace and blank lines are dropped. Returns "" if the
+// snippet contains no non-whitespace content.
+func normalizeSnippet(s string) string {
+	if s == "" {
+		return ""
+	}
+	lines := strings.Split(s, "\n")
+	out := make([]string, 0, len(lines))
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		out = append(out, trimmed)
+	}
+	return strings.Join(out, "\n")
+}

--- a/internal/sarif/sarif.go
+++ b/internal/sarif/sarif.go
@@ -10,11 +10,21 @@ type Log struct {
 }
 
 type Run struct {
-	Tool        Tool                   `json:"tool"`
-	Results     []Result               `json:"results"`
-	Taxonomies  []ToolComponent        `json:"taxonomies,omitempty"`
-	Invocations []Invocation           `json:"invocations,omitempty"`
-	Properties  map[string]interface{} `json:"properties,omitempty"`
+	Tool              Tool                   `json:"tool"`
+	Results           []Result               `json:"results"`
+	Taxonomies        []ToolComponent        `json:"taxonomies,omitempty"`
+	Invocations       []Invocation           `json:"invocations,omitempty"`
+	AutomationDetails *RunAutomationDetails  `json:"automationDetails,omitempty"`
+	BaselineGuid      string                 `json:"baselineGuid,omitempty"`
+	Properties        map[string]interface{} `json:"properties,omitempty"`
+}
+
+// RunAutomationDetails identifies a single analysis run, per SARIF 2.1.0
+// §3.17. The Guid is the stable identifier subsequent runs use to link back
+// to this one via Run.BaselineGuid.
+type RunAutomationDetails struct {
+	ID   string `json:"id,omitempty"`
+	Guid string `json:"guid,omitempty"`
 }
 
 type Invocation struct {
@@ -97,6 +107,7 @@ type Result struct {
 	Locations           []Location             `json:"locations,omitempty"`
 	Fingerprints        map[string]string      `json:"fingerprints,omitempty"`
 	PartialFingerprints map[string]string      `json:"partialFingerprints,omitempty"`
+	BaselineState       string                 `json:"baselineState,omitempty"`
 	Properties          map[string]interface{} `json:"properties,omitempty"`
 	Suppressions        []SARIFSuppression     `json:"suppressions,omitempty"`
 }

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -25,9 +25,10 @@ type Handlers struct {
 
 // analyzeRequestJSON is the JSON wire format for analyze requests.
 type analyzeRequestJSON struct {
-	Artifacts []artifactJSON `json:"artifacts"`
-	Config    config.Config  `json:"config"`
-	Rules     []rules.Rule   `json:"rules,omitempty"`
+	Artifacts  []artifactJSON `json:"artifacts"`
+	Config     config.Config  `json:"config"`
+	Rules      []rules.Rule   `json:"rules,omitempty"`
+	BaselineID string         `json:"baseline_id,omitempty"`
 }
 
 type artifactJSON struct {
@@ -90,9 +91,10 @@ func (h *Handlers) HandleAnalyze(w http.ResponseWriter, r *http.Request) {
 	}
 
 	result, err := h.analyze.Analyze(r.Context(), service.AnalyzeRequest{
-		Artifacts: toArtifacts(req.Artifacts),
-		Config:    req.Config,
-		Rules:     req.Rules,
+		Artifacts:  toArtifacts(req.Artifacts),
+		Config:     req.Config,
+		Rules:      req.Rules,
+		BaselineID: req.BaselineID,
 	})
 	if err != nil {
 		slog.Error("analyze failed", "error", err, "tenant", middleware.TenantFromContext(r.Context()), "request_id", middleware.RequestIDFromContext(r.Context()))
@@ -123,9 +125,10 @@ func (h *Handlers) HandleAnalyzeStream(w http.ResponseWriter, r *http.Request) {
 	sse.SetHeaders()
 
 	tierCh, resultCh, errCh := h.analyze.AnalyzeStream(r.Context(), service.AnalyzeRequest{
-		Artifacts: toArtifacts(req.Artifacts),
-		Config:    req.Config,
-		Rules:     req.Rules,
+		Artifacts:  toArtifacts(req.Artifacts),
+		Config:     req.Config,
+		Rules:      req.Rules,
+		BaselineID: req.BaselineID,
 	})
 
 	// Stream tier results

--- a/internal/service/analyze.go
+++ b/internal/service/analyze.go
@@ -60,6 +60,11 @@ func (s *AnalyzeService) Analyze(ctx context.Context, req AnalyzeRequest) (*Anal
 
 	sarifLog := sarif.Assemble(results, buildDescriptors(req.Config.Policies, req.Rules), scopeFromArtifacts(req.Artifacts), req.Config.Persona)
 
+	baselineSummary, err := s.applyBaseline(ctx, sarifLog, req.BaselineID)
+	if err != nil {
+		return nil, err
+	}
+
 	resultID, err := s.store.WriteSARIF(ctx, sarifLog)
 	if err != nil {
 		return nil, fmt.Errorf("storing SARIF: %w", err)
@@ -68,7 +73,39 @@ func (s *AnalyzeService) Analyze(ctx context.Context, req AnalyzeRequest) (*Anal
 	return &AnalyzeResult{
 		ResultID:      resultID,
 		TotalFindings: len(results),
+		Baseline:      baselineSummary,
 	}, nil
+}
+
+// applyBaseline stamps automation details onto sarifLog and, when
+// baselineID is non-empty, loads that baseline from the store and
+// annotates each result with a baselineState. Returns a BaselineSummary
+// with bucket counts when comparison ran, or nil when it didn't.
+func (s *AnalyzeService) applyBaseline(ctx context.Context, sarifLog *sarif.Log, baselineID string) (*BaselineSummary, error) {
+	sarif.EnsureAutomationDetails(sarifLog)
+	if baselineID == "" {
+		return nil, nil
+	}
+	baselineLog, err := s.store.ReadSARIF(ctx, baselineID)
+	if err != nil {
+		return nil, fmt.Errorf("loading baseline %q: %w", baselineID, err)
+	}
+	sarif.CompareBaseline(sarifLog, baselineLog)
+
+	summary := &BaselineSummary{Source: baselineID}
+	if len(sarifLog.Runs) > 0 {
+		for _, r := range sarifLog.Runs[0].Results {
+			switch r.BaselineState {
+			case sarif.BaselineStateNew:
+				summary.New++
+			case sarif.BaselineStateUnchanged:
+				summary.Unchanged++
+			case sarif.BaselineStateAbsent:
+				summary.Absent++
+			}
+		}
+	}
+	return summary, nil
 }
 
 // AnalyzeStream runs analysis progressively, emitting per-tier results on a channel.
@@ -150,6 +187,13 @@ func (s *AnalyzeService) AnalyzeStream(ctx context.Context, req AnalyzeRequest) 
 
 		// Store final SARIF
 		sarifLog := sarif.Assemble(allResults, buildDescriptors(req.Config.Policies, req.Rules), scopeFromArtifacts(req.Artifacts), req.Config.Persona)
+
+		baselineSummary, baselineErr := s.applyBaseline(ctx, sarifLog, req.BaselineID)
+		if baselineErr != nil {
+			errCh <- baselineErr
+			return
+		}
+
 		resultID, err := s.store.WriteSARIF(ctx, sarifLog)
 		if err != nil {
 			errCh <- fmt.Errorf("storing SARIF: %w", err)
@@ -159,6 +203,7 @@ func (s *AnalyzeService) AnalyzeStream(ctx context.Context, req AnalyzeRequest) 
 		resultCh <- AnalyzeResult{
 			ResultID:      resultID,
 			TotalFindings: len(allResults),
+			Baseline:      baselineSummary,
 		}
 	}()
 

--- a/internal/service/analyze_test.go
+++ b/internal/service/analyze_test.go
@@ -16,6 +16,9 @@ import (
 type mockStore struct {
 	writtenSARIF *sarif.Log
 	writtenID    string
+	// readReturn, if non-nil, is returned from ReadSARIF instead of
+	// echoing writtenSARIF — used to pre-seed a baseline log.
+	readReturn *sarif.Log
 }
 
 func (m *mockStore) WriteSARIF(_ context.Context, doc *sarif.Log) (string, error) {
@@ -29,6 +32,9 @@ func (m *mockStore) WriteVerdict(_ context.Context, _ string, _ *store.Verdict) 
 }
 
 func (m *mockStore) ReadSARIF(_ context.Context, _ string) (*sarif.Log, error) {
+	if m.readReturn != nil {
+		return m.readReturn, nil
+	}
 	return m.writtenSARIF, nil
 }
 
@@ -75,6 +81,138 @@ func TestAnalyzeService_Analyze(t *testing.T) {
 	}
 	if ms.writtenSARIF == nil {
 		t.Fatal("expected SARIF to be written to store")
+	}
+}
+
+// mockFindingClient returns a pre-configured finding list so we can
+// exercise baseline comparison end-to-end through the service.
+type mockFindingClient struct {
+	findings []analyzer.Finding
+}
+
+func (m *mockFindingClient) AnalyzeCode(_ context.Context, _ string, _ string, _ string, _ string) ([]analyzer.Finding, error) {
+	return m.findings, nil
+}
+
+func TestAnalyzeService_Analyze_WithBaseline(t *testing.T) {
+	// Seed the "previous run" SARIF that will act as the baseline. The
+	// baseline contains one error-level finding whose content matches
+	// what the mock client will surface again.
+	baselineLog := sarif.NewLog("gavel", "0.1.0")
+	baselineLog.Runs[0].AutomationDetails = &sarif.RunAutomationDetails{Guid: "baseline-guid-xyz"}
+	baselineLog.Runs[0].Results = []sarif.Result{
+		{
+			RuleID:  "bug-detection",
+			Level:   "error",
+			Message: sarif.Message{Text: "seen"},
+			Locations: []sarif.Location{{PhysicalLocation: sarif.PhysicalLocation{
+				ArtifactLocation: sarif.ArtifactLocation{URI: "test.go"},
+				Region: sarif.Region{
+					StartLine: 5, EndLine: 5,
+					Snippet: &sarif.ArtifactContent{Text: "password := \"hunter2\"\n"},
+				},
+			}}},
+		},
+	}
+	sarif.SetContentFingerprint(&baselineLog.Runs[0].Results[0])
+
+	ms := &mockStore{readReturn: baselineLog}
+
+	// Current run: the mock returns one finding that matches the
+	// baseline content (so it should come out "unchanged") and another
+	// that does not (so it should come out "new"). The baseline's fixed
+	// finding should be inherited as "absent" — but here baseline ==
+	// current for the matched line, so we only exercise unchanged + new.
+	svc := NewAnalyzeService(ms).WithClientFactory(func(_ config.ProviderConfig) analyzer.BAMLClient {
+		return &mockFindingClient{
+			findings: []analyzer.Finding{
+				{RuleID: "bug-detection", Level: "error", Message: "seen", StartLine: 42, EndLine: 42},
+				{RuleID: "bug-detection", Level: "warning", Message: "fresh", StartLine: 60, EndLine: 60},
+			},
+		}
+	})
+
+	req := AnalyzeRequest{
+		Artifacts: []input.Artifact{{
+			Path:    "test.go",
+			Content: "line1\nline2\nline3\nline4\npassword := \"hunter2\"\nline6\nline7\nline8\nline9\nline10\nline11\nline12\nline13\nline14\nline15\nline16\nline17\nline18\nline19\nline20\nline21\nline22\nline23\nline24\nline25\nline26\nline27\nline28\nline29\nline30\nline31\nline32\nline33\nline34\nline35\nline36\nline37\nline38\nline39\nline40\nline41\npassword := \"hunter2\"\nline43\nline44\nline45\nline46\nline47\nline48\nline49\nline50\nline51\nline52\nline53\nline54\nline55\nline56\nline57\nline58\nline59\ndifferentFresh := 1\n",
+			Kind:    input.KindFile,
+		}},
+		Config: config.Config{
+			Provider: config.ProviderConfig{Name: "test"},
+			Persona:  "code-reviewer",
+			Policies: map[string]config.Policy{
+				"bug-detection": {Enabled: true, Description: "Find bugs", Severity: "warning"},
+			},
+		},
+		BaselineID: "any-id", // mockStore ignores the ID and returns readReturn
+	}
+
+	result, err := svc.Analyze(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Baseline == nil {
+		t.Fatal("expected Baseline summary to be populated")
+	}
+	if result.Baseline.New != 1 {
+		t.Errorf("expected 1 new finding, got %d", result.Baseline.New)
+	}
+	if result.Baseline.Unchanged != 1 {
+		t.Errorf("expected 1 unchanged finding, got %d", result.Baseline.Unchanged)
+	}
+	if result.Baseline.Absent != 0 {
+		t.Errorf("expected 0 absent findings, got %d", result.Baseline.Absent)
+	}
+
+	// The stored SARIF should carry the baseline guid link back to the
+	// previous run, and a fresh automation guid of its own.
+	if ms.writtenSARIF == nil || len(ms.writtenSARIF.Runs) == 0 {
+		t.Fatal("expected SARIF to be written to store")
+	}
+	run := ms.writtenSARIF.Runs[0]
+	if run.BaselineGuid != "baseline-guid-xyz" {
+		t.Errorf("BaselineGuid = %q, want %q", run.BaselineGuid, "baseline-guid-xyz")
+	}
+	if run.AutomationDetails == nil || run.AutomationDetails.Guid == "" {
+		t.Error("expected AutomationDetails.Guid to be stamped on the new run")
+	}
+	if run.AutomationDetails != nil && run.AutomationDetails.Guid == "baseline-guid-xyz" {
+		t.Error("new run should have its own guid, not share the baseline's")
+	}
+}
+
+func TestAnalyzeService_Analyze_StampsAutomationDetailsWithoutBaseline(t *testing.T) {
+	// Even without a baseline, every stored run should carry an
+	// automation guid so the next run can reference it.
+	ms := &mockStore{}
+	svc := NewAnalyzeService(ms).WithClientFactory(func(_ config.ProviderConfig) analyzer.BAMLClient {
+		return &mockBAMLClient{}
+	})
+
+	_, err := svc.Analyze(context.Background(), AnalyzeRequest{
+		Artifacts: []input.Artifact{{Path: "test.go", Content: "package main\n", Kind: input.KindFile}},
+		Config: config.Config{
+			Provider: config.ProviderConfig{Name: "test"},
+			Persona:  "code-reviewer",
+			Policies: map[string]config.Policy{
+				"bug-detection": {Enabled: true, Description: "Find bugs", Severity: "warning"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if ms.writtenSARIF == nil || len(ms.writtenSARIF.Runs) == 0 {
+		t.Fatal("expected SARIF to be written")
+	}
+	run := ms.writtenSARIF.Runs[0]
+	if run.AutomationDetails == nil || run.AutomationDetails.Guid == "" {
+		t.Error("expected AutomationDetails.Guid to be set even without --baseline")
+	}
+	if run.BaselineGuid != "" {
+		t.Errorf("expected empty BaselineGuid without baseline, got %q", run.BaselineGuid)
 	}
 }
 

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -16,6 +16,11 @@ type AnalyzeRequest struct {
 	Artifacts []input.Artifact
 	Config    config.Config
 	Rules     []rules.Rule
+	// BaselineID, if non-empty, identifies a previously stored SARIF
+	// result to compare against. Each finding in the new run will be
+	// annotated with a baselineState (new, unchanged, or absent).
+	// Empty disables baseline comparison.
+	BaselineID string
 }
 
 // TierResult represents results from a single analysis tier.
@@ -26,10 +31,21 @@ type TierResult struct {
 	Error     string         `json:"error,omitempty"`
 }
 
+// BaselineSummary breaks down how many results in an AnalyzeResult fell
+// into each baselineState bucket. It is zero-valued when baseline
+// comparison was not performed.
+type BaselineSummary struct {
+	Source    string `json:"source,omitempty"`
+	New       int    `json:"new"`
+	Unchanged int    `json:"unchanged"`
+	Absent    int    `json:"absent"`
+}
+
 // AnalyzeResult is the final summary after all tiers complete.
 type AnalyzeResult struct {
-	ResultID      string `json:"result_id"`
-	TotalFindings int    `json:"total_findings"`
+	ResultID      string           `json:"result_id"`
+	TotalFindings int              `json:"total_findings"`
+	Baseline      *BaselineSummary `json:"baseline,omitempty"`
 }
 
 // JudgeRequest is the transport-agnostic input for evaluation.

--- a/internal/store/baseline.go
+++ b/internal/store/baseline.go
@@ -1,0 +1,30 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/chris-regnier/gavel/internal/sarif"
+)
+
+// LoadBaseline resolves ref to a baseline SARIF log. If ref points at an
+// existing file it is decoded directly; otherwise ref is treated as a
+// stored result ID and read via s.ReadSARIF. This lets callers accept
+// either a downloaded CI artifact (`./prev/sarif.json`) or a local
+// result ID (`2026-04-12T...-abcdef`) with a single interface.
+func LoadBaseline(ctx context.Context, s Store, ref string) (*sarif.Log, error) {
+	if info, err := os.Stat(ref); err == nil && !info.IsDir() {
+		data, err := os.ReadFile(ref)
+		if err != nil {
+			return nil, err
+		}
+		var log sarif.Log
+		if err := json.Unmarshal(data, &log); err != nil {
+			return nil, fmt.Errorf("decoding baseline SARIF %q: %w", ref, err)
+		}
+		return &log, nil
+	}
+	return s.ReadSARIF(ctx, ref)
+}

--- a/internal/store/baseline_test.go
+++ b/internal/store/baseline_test.go
@@ -1,0 +1,78 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/chris-regnier/gavel/internal/sarif"
+)
+
+func TestLoadBaseline_FromStoreID(t *testing.T) {
+	dir := t.TempDir()
+	fs := NewFileStore(dir)
+	ctx := context.Background()
+
+	log := sarif.NewLog("gavel", "0.1.0")
+	log.Runs[0].Results = []sarif.Result{{RuleID: "r1"}}
+	id, err := fs.WriteSARIF(ctx, log)
+	if err != nil {
+		t.Fatalf("WriteSARIF: %v", err)
+	}
+
+	got, err := LoadBaseline(ctx, fs, id)
+	if err != nil {
+		t.Fatalf("LoadBaseline by id: %v", err)
+	}
+	if len(got.Runs) == 0 || len(got.Runs[0].Results) != 1 || got.Runs[0].Results[0].RuleID != "r1" {
+		t.Errorf("unexpected log round-trip: %+v", got)
+	}
+}
+
+func TestLoadBaseline_FromFilePath(t *testing.T) {
+	dir := t.TempDir()
+	log := sarif.NewLog("gavel", "0.1.0")
+	log.Runs[0].Results = []sarif.Result{{RuleID: "file-rule"}}
+	data, err := json.Marshal(log)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	path := filepath.Join(dir, "prev.sarif.json")
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	// Use a filestore that points at a DIFFERENT directory to prove
+	// the file path takes precedence over the store ID lookup.
+	fs := NewFileStore(t.TempDir())
+
+	got, err := LoadBaseline(context.Background(), fs, path)
+	if err != nil {
+		t.Fatalf("LoadBaseline by path: %v", err)
+	}
+	if len(got.Runs) == 0 || got.Runs[0].Results[0].RuleID != "file-rule" {
+		t.Errorf("unexpected log: %+v", got)
+	}
+}
+
+func TestLoadBaseline_MissingID(t *testing.T) {
+	dir := t.TempDir()
+	fs := NewFileStore(dir)
+	if _, err := LoadBaseline(context.Background(), fs, "does-not-exist"); err == nil {
+		t.Error("expected error for missing id")
+	}
+}
+
+func TestLoadBaseline_InvalidFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bogus.json")
+	if err := os.WriteFile(path, []byte("not-json"), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	fs := NewFileStore(t.TempDir())
+	if _, err := LoadBaseline(context.Background(), fs, path); err == nil {
+		t.Error("expected error for invalid JSON in baseline file")
+	}
+}


### PR DESCRIPTION
Completes the second half of #80: every SARIF result now carries a `baselineState` (`new` | `unchanged` | `absent`) when analyze is run with a baseline. Results inherit the baseline run's `automationDetails.guid` via `Run.baselineGuid`, and every new run gets a fresh GUID stamped onto `Run.automationDetails` so the next run can reference it. Matching uses the content-based fingerprint added in #98, so line shifts and whitespace-only reformatting no longer masquerade as new findings.

Support is wired into every transport that calls into gavel's analyze pipeline: the `gavel analyze` CLI, all three MCP `analyze_*` tools, and both HTTP service endpoints. The default Rego gate is also updated so that baseline tracking actually gates on regressions instead of pre-existing noise.

## Summary

- **`internal/sarif/baseline.go`** — new `CompareBaseline(current, baseline)` annotates each current result with its state relative to a baseline, appends baseline findings that went missing as `baselineState=absent`, and copies the baseline's automation GUID onto `current.Runs[0].BaselineGuid`. Baseline log is never mutated. `EnsureAutomationDetails` stamps a fresh v4 UUID on a run when one isn't already set.
- **`internal/sarif/sarif.go`** — adds `Run.AutomationDetails` (`*RunAutomationDetails` with `id`+`guid`), `Run.BaselineGuid`, and `Result.BaselineState`, per SARIF 2.1.0 §3.17 / §3.27.19. All additive with `omitempty`.
- **`internal/sarif/fingerprint.go`** — content-hash computation moved out of the output formatter so `Assemble()` populates it on every stored log (previously it was only set when the `SARIFFormatter` rendered console output, which meant the stored `sarif.json` — the thing you'd want as a baseline — had no fingerprints).
- **`cmd/gavel/analyze.go`** — new `--baseline <id-or-path>` flag. Accepts either a stored result ID or a path to a `sarif.json` file (CI can point at a downloaded artifact). Summary JSON gains a `baseline: {source, new, unchanged, absent}` block when the flag is set.
- **`internal/mcp/server.go`** — `analyze_file`, `analyze_directory`, and `analyze_diff` each gain an optional `baseline` tool parameter. A shared `handlers.applyBaseline` helper stamps automation details, loads the baseline via `store.LoadBaseline`, and returns bucket counts for the tool summary.
- **`internal/service/analyze.go`** + `types.go` — `AnalyzeRequest` gains `BaselineID`; `AnalyzeResult` gains `*BaselineSummary`. Both `Analyze` and `AnalyzeStream` call `EnsureAutomationDetails` on every run and `CompareBaseline` when `BaselineID` is set.
- **`internal/server/handlers.go`** — threads `baseline_id` through the `/v1/analyze` and `/v1/analyze/stream` JSON wire formats.
- **`internal/store/baseline.go`** — `LoadBaseline(ctx, Store, ref)` is a shared resolver (file path if it exists on disk, otherwise a store ID lookup) used by CLI + MCP. HTTP service sticks to ID-only via the store directly.
- **`internal/evaluator/default.rego`** — the footgun fix. The default gate previously counted every unsuppressed result, so a `--baseline` run that appended fixed findings as `absent` could still trigger a reject (the opposite of what baseline tracking is for). A new `actionable_results` set layers two filters on top of `unsuppressed_results`:
  - `_is_fixed` drops `baselineState == "absent"` (finding fixed this PR)
  - `_is_pre_existing` drops `baselineState == "unchanged"` (noise predating this PR)

  Runs without `--baseline` don't carry any `baselineState`, so both filters are no-ops and existing semantics are preserved. With `--baseline`, gating now correctly acts on regressions only.

**LSP intentionally untouched.** `internal/lsp/analyzer.go` is a live per-file diagnostics path that returns `[]sarif.Result` directly to the editor without ever calling `Assemble` or writing to the store — baseline tracking has no prior run to compare against.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./...` full suite green
- [x] New test coverage:
  - `internal/sarif/baseline_test.go` — 10 tests: mixed states, all-new, all-unchanged, `baselineGuid` propagation, line-shift stability, fingerprintless-result handling, nil/empty-runs no-ops, non-mutation of the baseline log, GUID shape/preservation/uniqueness
  - `internal/sarif/assembler_test.go` — `TestAssemble_PopulatesContentFingerprints` confirms fingerprints are now set at assembly time
  - `internal/evaluator/evaluator_test.go` — 4 baseline-aware Rego tests: fixed ignored, pre-existing ignored, new still rejects, mixed new + pre-existing rejects on the regression
  - `internal/service/analyze_test.go` — `TestAnalyzeService_Analyze_WithBaseline` (pre-seeded baseline produces new=1/unchanged=1, `BaselineGuid` propagated, fresh automation GUID on the new run) and `TestAnalyzeService_Analyze_StampsAutomationDetailsWithoutBaseline`
  - `internal/mcp/server_test.go` — 3 `TestApplyBaseline_*` tests covering the full flow through a real filestore, the no-baseline path, and the error path for an unknown baseline ID
  - `internal/store/baseline_test.go` — 4 `TestLoadBaseline_*` tests covering the store-ID branch, the file-path branch (with a store pointed at a *different* directory to prove path takes precedence), and both error cases
- [x] Existing `TestEvaluator_Reject/Merge/Review` tests pass unchanged (confirms no-baseline behaviour is preserved)
- [x] `go build ./cmd/gavel` + `gavel analyze --help` shows the new `--baseline` flag

https://claude.ai/code/session_01Lh2MbbjKVkKAm1MkC4usra