### PR TITLE
feat(release): add task release:dry-run (#91)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,7 @@ task test           # go test ./... -v
 task lint           # go vet ./...
 task generate       # baml-cli generate (regenerates baml_client/ from baml_src/)
 task check          # full CI parity: generate + lint + test + cross-compile (run before pushing)
+task release:dry-run  # rehearse the release pipeline locally (no tag, no push, no gh release)
 
 # Run a single test
 go test ./internal/config/ -run TestMergeOverrides -v
@@ -202,6 +203,7 @@ git push origin v0.2.0
 ```bash
 task build              # Current platform only
 task build:release      # All architectures for current OS
+task release:dry-run    # Full release rehearsal (test + build + changelog, no publish)
 ```
 
 **Requirements:**

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -182,6 +182,44 @@ tasks:
       - git push origin {{.VERSION}}
       - echo "✓ Tag {{.VERSION}} created and pushed. GitHub Actions will build the release."
 
+  release:dry-run:
+    desc: Rehearse the release pipeline locally without tagging, pushing, or creating a release
+    cmds:
+      - rm -rf dist
+      - mkdir -p dist
+      - echo "==> Running tests..."
+      - task: test
+      - echo "==> Building release binaries for current OS..."
+      - task: build:release
+      - |
+        echo "==> Generating changelog..."
+        PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
+        if [ -n "$PREV_TAG" ]; then
+          echo "## Changes since $PREV_TAG" > dist/CHANGELOG.md
+          echo "" >> dist/CHANGELOG.md
+          git log $PREV_TAG..HEAD --pretty=format:"- %s (%h)" --no-merges >> dist/CHANGELOG.md
+        else
+          echo "## Initial Release" > dist/CHANGELOG.md
+        fi
+      - |
+        echo ""
+        echo "==> Dry-run complete. Artifacts in dist/:"
+        ls -lh dist/
+        echo ""
+        echo "==> Checksums:"
+        cat dist/checksums.txt
+        echo ""
+        echo "==> Changelog:"
+        cat dist/CHANGELOG.md
+        echo ""
+        VERSION=$(git describe --tags --always --dirty)
+        echo "==> Would run:"
+        echo "    gh release create $VERSION \\"
+        echo "      --title \"Gavel $VERSION\" \\"
+        echo "      --notes-file dist/CHANGELOG.md \\"
+        echo "      dist/*.tar.gz \\"
+        echo "      dist/checksums.txt"
+
   bench:build:
     desc: Build gavel-bench binary
     cmds:

--- a/docs/superpowers/specs/2026-04-09-release-pipeline-cleanup-design.md
+++ b/docs/superpowers/specs/2026-04-09-release-pipeline-cleanup-design.md
@@ -209,7 +209,7 @@ Each of the following becomes a separate GitHub issue on `chris-regnier/gavel`, 
 4. **Node 20 action deprecation.** Upgrade `actions/checkout`, `actions/setup-go`, `actions/upload-artifact`, `go-task/setup-task` to Node-24-compatible versions before the forced cutover.
 5. **Host-OS-independent release builds.** Either teach `task build:release` to build both OSes from one host (osxcross / zig cc), or migrate to native arm64 runners (`ubuntu-24.04-arm`) or GoReleaser so cross-compile pain disappears.
 6. **Partial-release failure handling.** Currently when one OS leg fails, the other leg's artifacts are uploaded and then discarded. Define a retry path (re-run failed job) or a safe-restart story that does not require deleting and re-pushing the tag.
-7. **Release dry-run task.** Add `task release:dry-run` that runs everything the release workflow would run, locally, without pushing a tag. Lets us rehearse changes to the pipeline safely.
+7. ~~**Release dry-run task.**~~ Implemented in #91. `task release:dry-run` runs tests, builds release binaries, generates a changelog, and shows what `gh release create` would run — all without tagging, pushing, or creating a release.
 
 Each issue body includes: the problem, why we deferred it from this cleanup, a brief acceptance criterion, and a link to this spec.
 
@@ -229,4 +229,4 @@ Each issue body includes: the problem, why we deferred it from this cleanup, a b
 - **`gh api` branch protection is shared state.** The user has approved this action explicitly, but the command will be displayed and confirmed once more at runtime, with current protection state fetched first, to avoid clobbering any unrelated settings that may have been added since.
 - **Check names are fragile.** `test (ubuntu-latest)` and `test (macos-latest)` are GitHub's auto-generated matrix display names. If the matrix key or values change, the required-check names change and branch protection silently stops enforcing. This risk is accepted for now; a follow-up could pin display names via `name:` on the job.
 - **`task check` on an M-series Mac runs darwin/arm64 twice (native + cross) and darwin/amd64 once.** Fine — it is still catching breakage, just not the minimum possible work. Optimizing this is out of scope.
-- **Rehearsal before tag cut.** This spec does not add a release dry-run (deferred to Option C issue 7). The first real verification of the fix will be re-cutting `v0.6.0` or `v0.6.1`. We accept that.
+- ~~**Rehearsal before tag cut.**~~ Resolved — `task release:dry-run` now provides local rehearsal (#91).

--- a/docs/superpowers/specs/2026-04-13-sarif-fixes-design.md
+++ b/docs/superpowers/specs/2026-04-13-sarif-fixes-design.md
@@ -1,0 +1,133 @@
+# SARIF `fixes` for auto-remediation
+
+**Issue**: chris-regnier/gavel#78
+**Status**: Design approved, ready for implementation plan
+**Scope**: Narrow — BAML schema + SARIF structs + analyzer wiring. LSP consumption is a follow-up issue.
+
+## Motivation
+
+The BAML `AnalyzeCode` function already returns a free-text `recommendation` for each finding. SARIF 2.1.0 defines a structured `fixes` field that supports machine-applicable replacements. Emitting structured fixes unlocks:
+
+- One-click quick-fixes in the Gavel LSP (follow-up issue)
+- Auto-fix suggestions in GitHub Code Scanning
+- CI-based auto-remediation workflows
+
+The existing `gavel/recommendation` property stays in place for backward compatibility; the new `fixes` field is additive.
+
+## Approach
+
+The LLM produces one optional `fixReplacementText` per finding. It reuses the finding's own `startLine`/`endLine` as the region to replace. On output, Gavel maps this into the spec-compliant `Fix`/`ArtifactChange`/`Replacement` structure.
+
+This keeps the prompt simple (one extra field, easy for small models to fill reliably) while emitting fully spec-compliant SARIF. Column-level precision and multi-region fixes are out of scope — they can be added later if needed.
+
+## BAML Schema Change
+
+In `baml_src/analyze.baml`, add one optional field to the `Finding` class:
+
+```
+class Finding {
+  // ... existing fields ...
+  fixReplacementText string?  // Optional: raw text to replace the flagged region with
+}
+```
+
+Prompt instruction updates inside `AnalyzeCode`:
+
+- When a finding has a clear, machine-applicable fix, provide raw replacement text spanning exactly `startLine` to `endLine`.
+- For vague or structural findings ("consider restructuring"), leave `fixReplacementText` empty.
+- Provide raw text without markdown code fences.
+
+After schema changes, `task generate` regenerates `baml_client/`. In `internal/analyzer/bamlclient.go`, `convertFindings()` copies the new field into `analyzer.Finding`, which gains a corresponding `FixReplacementText string` field (empty string when absent).
+
+## SARIF Struct Additions
+
+In `internal/sarif/sarif.go`, add three new types per SARIF 2.1.0:
+
+```go
+type Fix struct {
+    Description     Message          `json:"description,omitempty"`
+    ArtifactChanges []ArtifactChange `json:"artifactChanges"`
+}
+
+type ArtifactChange struct {
+    ArtifactLocation ArtifactLocation `json:"artifactLocation"`
+    Replacements     []Replacement    `json:"replacements"`
+}
+
+type Replacement struct {
+    DeletedRegion   Region           `json:"deletedRegion"`
+    InsertedContent *ArtifactContent `json:"insertedContent,omitempty"`
+}
+```
+
+Extend `sarif.Result` with an optional `Fixes` field:
+
+```go
+type Result struct {
+    // ... existing fields ...
+    Fixes []Fix `json:"fixes,omitempty"`
+}
+```
+
+`omitempty` keeps SARIF output unchanged for findings without fixes — backward compatible with all existing consumers.
+
+`Replacement.DeletedRegion` reuses the existing `Region` struct (startLine/endLine). `InsertedContent` reuses `ArtifactContent` (which has a `Text` field). No duplication.
+
+## Analyzer → SARIF Wiring
+
+In `internal/analyzer/analyzer.go`, inside the result-building loop, after constructing `result := sarif.Result{...}`, conditionally attach a fix:
+
+```go
+if f.FixReplacementText != "" {
+    result.Fixes = []sarif.Fix{{
+        Description: sarif.Message{Text: f.Recommendation},
+        ArtifactChanges: []sarif.ArtifactChange{{
+            ArtifactLocation: sarif.ArtifactLocation{URI: path},
+            Replacements: []sarif.Replacement{{
+                DeletedRegion: sarif.Region{
+                    StartLine: f.StartLine,
+                    EndLine:   f.EndLine,
+                },
+                InsertedContent: &sarif.ArtifactContent{
+                    Text: f.FixReplacementText,
+                },
+            }},
+        }},
+    }}
+}
+```
+
+The fix's `description` reuses the existing `recommendation` text (human-readable summary). The replacement carries the machine-applicable payload. `gavel/recommendation` stays in `Properties` for backward compatibility — consumers that don't understand `fixes` still get the text.
+
+### Deduplication
+
+In `internal/sarif/assembler.go`, the existing dedup logic keeps the highest-confidence result among overlapping findings. Because `Fixes` is attached to the `Result` before dedup runs, the surviving result naturally carries its own fix — no extra merging logic needed.
+
+## Testing
+
+1. **`internal/sarif/sarif_test.go`** — JSON marshaling tests for `Fix`/`ArtifactChange`/`Replacement`. Verify a `Result` with `Fixes` serializes to spec-compliant JSON matching the shape in the issue, and a `Result` without `Fixes` omits the field entirely.
+
+2. **`internal/analyzer/analyzer_test.go`** — Use the existing mock `BAMLClient` to return a `Finding` with `FixReplacementText` populated. Assert the resulting `sarif.Result` has `Fixes` with the expected `DeletedRegion` and `InsertedContent`. Also test the empty case: a `Finding` with empty `FixReplacementText` produces a `Result` with no `Fixes`.
+
+3. **`internal/sarif/assembler_test.go`** — Verify deduplication preserves `Fixes` on the surviving result (highest-confidence wins, its fix travels with it).
+
+4. **Integration test** — Existing `TestIntegration` in `cmd/gavel/` should continue passing unchanged (fix is optional). Add one assertion that when the mock returns a fix, the final SARIF output contains a `fixes` array.
+
+No test needed for the BAML `fixReplacementText` field itself — coverage comes via the analyzer tests through the mock, and the BAML generator is trusted.
+
+## Edge Cases
+
+1. **LLM returns fix with wrong line range**: Can't verify — we trust the LLM's stated region. SARIF `fixes` is advisory; downstream tools should apply with user review.
+
+2. **LLM returns fix for a `none`-level finding**: Still include it. Severity governs verdict evaluation, not fix availability.
+
+3. **Fix spans beyond file bounds**: Not validated at SARIF emission. Consumers handle this.
+
+4. **Markdown code fences in replacement text**: The prompt explicitly instructs raw text. If small models ignore the instruction in practice, add a strip pass in `convertFindings()` in `bamlclient.go` (post-implementation check).
+
+## Out of Scope
+
+- LSP code action consumption of the new `Fixes` field (separate follow-up issue).
+- Multi-region or multi-file fixes.
+- Column-level precision in `DeletedRegion`.
+- Validation that replacement text actually fits the region.


### PR DESCRIPTION
## Summary

- Adds `task release:dry-run` that rehearses the full release pipeline locally — runs tests, builds release binaries for the current OS (amd64 + arm64), generates a changelog, and prints the `gh release create` command that *would* run — all without tagging, pushing, or creating a GitHub release.
- Updates CLAUDE.md with the new command in both the Build & Development Commands and Release Process sections.
- Marks the deferred dry-run item as resolved in the release pipeline cleanup design doc.

Closes #91

## Test plan

- [x] `task release:dry-run` completes successfully on macOS
- [x] Produces correct `dist/` layout: tarballs, raw binaries, checksums.txt, CHANGELOG.md
- [x] Checksums verify (`cd dist && shasum -a 256 -c checksums.txt` → OK)
- [x] No tag created, no push, no `gh release create` executed

🤖 Generated with [Claude Code](https://claude.com/claude-code)