### PR TITLE
ci: upgrade GitHub Actions off Node 20 before forced cutover

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -24,10 +24,10 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.25'
 
@@ -54,7 +54,7 @@ jobs:
             --output benchmarks/results/latest.json
 
       - name: Upload benchmark results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: benchmark-results-${{ github.sha }}
           path: benchmarks/results/latest.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.25'
           cache: true
@@ -27,7 +27,7 @@ jobs:
         uses: ./.github/actions/install-tools
 
       - name: Install Task
-        uses: go-task/setup-task@v1
+        uses: go-task/setup-task@v2
 
       - name: Install cross-compile toolchain
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,11 +22,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/configure-pages@v5
+      - uses: actions/configure-pages@v6
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: docs
 
@@ -39,4 +39,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/gavel.yml
+++ b/.github/workflows/gavel.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -140,12 +140,12 @@ jobs:
     if: contains(github.event.pull_request.title, '/benchmark')
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.25'
           cache: true
@@ -154,7 +154,7 @@ jobs:
         uses: ./.github/actions/install-tools
 
       - name: Install Task
-        uses: go-task/setup-task@v1
+        uses: go-task/setup-task@v2
 
       - name: Build Gavel from source
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.25'
 
@@ -31,7 +31,7 @@ jobs:
           sudo apt-get install -y gcc-aarch64-linux-gnu
 
       - name: Install Task
-        uses: go-task/setup-task@v1
+        uses: go-task/setup-task@v2
 
       - name: Run Tests
         run: task test
@@ -40,7 +40,7 @@ jobs:
         run: task build:release
 
       - name: Upload Linux artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist-linux
           path: dist/
@@ -50,12 +50,12 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.25'
 
@@ -63,7 +63,7 @@ jobs:
         uses: ./.github/actions/install-tools
 
       - name: Install Task
-        uses: go-task/setup-task@v1
+        uses: go-task/setup-task@v2
 
       - name: Run Tests
         run: task test
@@ -72,7 +72,7 @@ jobs:
         run: task build:release
 
       - name: Upload macOS artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist-macos
           path: dist/
@@ -83,18 +83,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Download Linux artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist-linux
           path: dist-linux/
 
       - name: Download macOS artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist-macos
           path: dist-macos/

--- a/docs/superpowers/plans/2026-04-13-github-actions-node24-upgrade.md
+++ b/docs/superpowers/plans/2026-04-13-github-actions-node24-upgrade.md
@@ -1,0 +1,223 @@
+# GitHub Actions Node 24 Upgrade Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Upgrade all GitHub Actions to Node-24-compatible versions to eliminate deprecation warnings before the 2026-06-02 forced cutover.
+
+**Architecture:** Mechanical version bump across 5 workflow files. No structural changes.
+
+**Tech Stack:** GitHub Actions YAML
+
+---
+
+### Task 1: Upgrade CI workflow
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+
+- [ ] **Step 1: Bump action versions in ci.yml**
+
+Apply these version changes:
+
+```yaml
+# Line 18: actions/checkout@v4 → actions/checkout@v5
+- uses: actions/checkout@v5
+
+# Line 21: actions/setup-go@v5 → actions/setup-go@v6
+- uses: actions/setup-go@v6
+
+# Line 30: go-task/setup-task@v1 → go-task/setup-task@v2
+- uses: go-task/setup-task@v2
+```
+
+- [ ] **Step 2: Verify YAML is valid**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`
+Expected: no output (success)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "ci: upgrade ci.yml actions to Node 24 (#93)"
+```
+
+### Task 2: Upgrade release workflow
+
+**Files:**
+- Modify: `.github/workflows/release.yml`
+
+- [ ] **Step 1: Bump action versions in release.yml**
+
+Apply these version changes:
+
+```yaml
+# build-linux job:
+# Line 15: actions/checkout@v4 → actions/checkout@v5
+- uses: actions/checkout@v5
+
+# Line 21: actions/setup-go@v5 → actions/setup-go@v6
+- uses: actions/setup-go@v6
+
+# Line 34: go-task/setup-task@v1 → go-task/setup-task@v2
+- uses: go-task/setup-task@v2
+
+# Line 43: actions/upload-artifact@v4 → actions/upload-artifact@v7
+- uses: actions/upload-artifact@v7
+
+# build-macos job:
+# Line 52: actions/checkout@v4 → actions/checkout@v5
+- uses: actions/checkout@v5
+
+# Line 58: actions/setup-go@v5 → actions/setup-go@v6
+- uses: actions/setup-go@v6
+
+# Line 65: go-task/setup-task@v1 → go-task/setup-task@v2
+- uses: go-task/setup-task@v2
+
+# Line 74: actions/upload-artifact@v4 → actions/upload-artifact@v7
+- uses: actions/upload-artifact@v7
+
+# release job:
+# Line 85: actions/checkout@v4 → actions/checkout@v5
+- uses: actions/checkout@v5
+
+# Line 91: actions/download-artifact@v4 → actions/download-artifact@v8
+- uses: actions/download-artifact@v8
+
+# Line 96: actions/download-artifact@v4 → actions/download-artifact@v8
+- uses: actions/download-artifact@v8
+```
+
+- [ ] **Step 2: Verify YAML is valid**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"`
+Expected: no output (success)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/release.yml
+git commit -m "ci: upgrade release.yml actions to Node 24 (#93)"
+```
+
+### Task 3: Upgrade docs workflow
+
+**Files:**
+- Modify: `.github/workflows/docs.yml`
+
+- [ ] **Step 1: Bump action versions in docs.yml**
+
+Apply these version changes:
+
+```yaml
+# build job:
+# Line 25: actions/checkout@v4 → actions/checkout@v5
+- uses: actions/checkout@v5
+
+# Line 27: actions/configure-pages@v5 → actions/configure-pages@v6
+- uses: actions/configure-pages@v6
+
+# Line 29: actions/upload-pages-artifact@v3 → actions/upload-pages-artifact@v5
+- uses: actions/upload-pages-artifact@v5
+
+# deploy job:
+# Line 41: actions/deploy-pages@v4 → actions/deploy-pages@v5
+- uses: actions/deploy-pages@v5
+```
+
+- [ ] **Step 2: Verify YAML is valid**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/docs.yml'))"`
+Expected: no output (success)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/docs.yml
+git commit -m "ci: upgrade docs.yml actions to Node 24 (#93)"
+```
+
+### Task 4: Upgrade benchmark workflow
+
+**Files:**
+- Modify: `.github/workflows/benchmark.yml`
+
+- [ ] **Step 1: Bump action versions in benchmark.yml**
+
+Apply these version changes:
+
+```yaml
+# Line 27: actions/checkout@v4 → actions/checkout@v5
+- uses: actions/checkout@v5
+
+# Line 30: actions/setup-go@v5 → actions/setup-go@v6
+- uses: actions/setup-go@v6
+
+# Line 57: actions/upload-artifact@v4 → actions/upload-artifact@v7
+- uses: actions/upload-artifact@v7
+```
+
+- [ ] **Step 2: Verify YAML is valid**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/benchmark.yml'))"`
+Expected: no output (success)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/benchmark.yml
+git commit -m "ci: upgrade benchmark.yml actions to Node 24 (#93)"
+```
+
+### Task 5: Upgrade gavel workflow
+
+**Files:**
+- Modify: `.github/workflows/gavel.yml`
+
+- [ ] **Step 1: Bump action versions in gavel.yml**
+
+Apply these version changes:
+
+```yaml
+# gate job:
+# Line 19: actions/checkout@v4 → actions/checkout@v5
+- uses: actions/checkout@v5
+
+# Line 119: github/codeql-action/upload-sarif@v4 — NO CHANGE (already Node 24)
+
+# benchmark job:
+# Line 143: actions/checkout@v4 → actions/checkout@v5
+- uses: actions/checkout@v5
+
+# Line 149: actions/setup-go@v5 → actions/setup-go@v6
+- uses: actions/setup-go@v6
+
+# Line 155: go-task/setup-task@v1 → go-task/setup-task@v2
+- uses: go-task/setup-task@v2
+```
+
+- [ ] **Step 2: Verify YAML is valid**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/gavel.yml'))"`
+Expected: no output (success)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/gavel.yml
+git commit -m "ci: upgrade gavel.yml actions to Node 24 (#93)"
+```
+
+### Task 6: Verify no Node 20 actions remain
+
+- [ ] **Step 1: Grep for old version references**
+
+Run: `grep -rn '@v[0-9]' .github/workflows/ | grep -v 'codeql-action/upload-sarif@v4'`
+
+Verify that no lines reference the old versions (`checkout@v4`, `setup-go@v5`, `upload-artifact@v4`, `download-artifact@v4`, `configure-pages@v5`, `upload-pages-artifact@v3`, `deploy-pages@v4`, `setup-task@v1`).
+
+- [ ] **Step 2: Run local CI check**
+
+Run: `task check`
+Expected: all checks pass (generate, lint, test, cross-compile)

--- a/docs/superpowers/specs/2026-04-13-github-actions-node24-upgrade-design.md
+++ b/docs/superpowers/specs/2026-04-13-github-actions-node24-upgrade-design.md
@@ -1,0 +1,55 @@
+# GitHub Actions Node 24 Upgrade
+
+**Status:** Approved
+**Date:** 2026-04-13
+**Issue:** #93
+**Scope:** Bump all GitHub Actions to Node-24-compatible versions to eliminate deprecation warnings before the 2026-06-02 forced cutover.
+
+## Background
+
+Every CI and release run emits deprecation warnings: Node.js 20 actions are deprecated. GitHub will force Node 24 by default on 2026-06-02 and remove Node 20 on 2026-09-16. This was deferred from the release pipeline cleanup (#91, see `docs/superpowers/specs/2026-04-09-release-pipeline-cleanup-design.md`).
+
+## Design
+
+Mechanical version bump across all 5 workflows. No structural changes to any workflow. No new steps, no removed steps, no config changes.
+
+### Version Upgrades
+
+| Action | Current | Target | Affected workflows |
+|--------|---------|--------|--------------------|
+| `actions/checkout` | `@v4` | `@v5` | ci, release, docs, benchmark, gavel |
+| `actions/setup-go` | `@v5` | `@v6` | ci, release, benchmark, gavel |
+| `actions/upload-artifact` | `@v4` | `@v7` | release, benchmark |
+| `actions/download-artifact` | `@v4` | `@v8` | release |
+| `actions/configure-pages` | `@v5` | `@v6` | docs |
+| `actions/upload-pages-artifact` | `@v3` | `@v5` | docs |
+| `actions/deploy-pages` | `@v4` | `@v5` | docs |
+| `go-task/setup-task` | `@v1` | `@v2` | ci, release, gavel |
+
+### No-Change Actions
+
+- `github/codeql-action/upload-sarif@v4` — already runs Node 24 (v4 was the Node 24 release).
+- `.github/actions/install-tools` — composite action (`runs.using: composite`), not a Node action. No change needed.
+
+### Files Changed
+
+1. `.github/workflows/ci.yml` — checkout, setup-go, setup-task
+2. `.github/workflows/release.yml` — checkout, setup-go, upload-artifact, download-artifact, setup-task
+3. `.github/workflows/docs.yml` — checkout, configure-pages, upload-pages-artifact, deploy-pages
+4. `.github/workflows/benchmark.yml` — checkout, setup-go, upload-artifact
+5. `.github/workflows/gavel.yml` — checkout, setup-go, setup-task
+
+### Breaking Change Assessment
+
+All target versions are the latest stable major from their respective `actions/` orgs. The workflows use only standard inputs (`go-version`, `cache`, `path`, `name`, `retention-days`, `fetch-depth`) — none of which were removed in any of these major bumps. The primary breaking change across all of them is the Node runtime bump itself (requires runner ≥ v2.327.1, which GitHub-hosted runners already satisfy).
+
+## Acceptance Criteria
+
+- All actions upgraded per the table above.
+- CI passes on both matrix legs (ubuntu-latest, macos-latest).
+- No Node 20 deprecation warnings in run logs.
+
+## Risks
+
+- **Runner version floor**: Node 24 actions require runner ≥ v2.327.1. GitHub-hosted runners (`ubuntu-latest`, `macos-latest`) already meet this. Self-hosted runners would not — but this project does not use any.
+- **upload-artifact v7 / download-artifact v8 compatibility**: These were released the same day (2026-02-26) and use the same underlying `@actions/artifact` library. The release workflow pairs them directly; this pairing is intentional and tested by the actions team.


### PR DESCRIPTION
## Summary

Closes #93.

- Upgrades all GitHub Actions to Node-24-compatible versions across all 5 workflows
- `codeql-action/upload-sarif@v4` and `.github/actions/install-tools` (composite) already Node 24 — unchanged
- No workflow structure changes, just version bumps

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | `@v4` | `@v5` |
| `actions/setup-go` | `@v5` | `@v6` |
| `actions/upload-artifact` | `@v4` | `@v7` |
| `actions/download-artifact` | `@v4` | `@v8` |
| `actions/configure-pages` | `@v5` | `@v6` |
| `actions/upload-pages-artifact` | `@v3` | `@v5` |
| `actions/deploy-pages` | `@v4` | `@v5` |
| `go-task/setup-task` | `@v1` | `@v2` |

## Test plan

- [ ] CI passes on both matrix legs (ubuntu-latest, macos-latest)
- [ ] No Node 20 deprecation warnings in run logs
- [ ] `task check` passes locally (confirmed pre-push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)