### PR TITLE
ci(release): recover gracefully when one OS leg fails (#92)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ env:
 
 jobs:
   build-linux:
+    if: github.event_name != 'workflow_dispatch' || github.actor == 'chris-regnier'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -56,6 +57,7 @@ jobs:
           retention-days: 1
 
   build-macos:
+    if: github.event_name != 'workflow_dispatch' || github.actor == 'chris-regnier'
     runs-on: macos-latest
     steps:
       - name: Checkout
@@ -88,6 +90,7 @@ jobs:
           retention-days: 1
 
   release:
+    if: github.event_name != 'workflow_dispatch' || github.actor == 'chris-regnier'
     needs: [build-linux, build-macos]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           name: dist-linux
           path: dist/
-          retention-days: 1
+          retention-days: 5
 
   build-macos:
     if: github.event_name != 'workflow_dispatch' || github.actor == 'chris-regnier'
@@ -89,7 +89,7 @@ jobs:
         with:
           name: dist-macos
           path: dist/
-          retention-days: 1
+          retention-days: 5
 
   release:
     if: github.event_name != 'workflow_dispatch' || github.actor == 'chris-regnier'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   build-linux:
-    if: github.event_name != 'workflow_dispatch' || github.actor == 'chris-regnier'
+    if: github.event_name != 'workflow_dispatch' || (github.actor == 'chris-regnier' && github.triggering_actor == 'chris-regnier')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -58,7 +58,7 @@ jobs:
           retention-days: 5
 
   build-macos:
-    if: github.event_name != 'workflow_dispatch' || github.actor == 'chris-regnier'
+    if: github.event_name != 'workflow_dispatch' || (github.actor == 'chris-regnier' && github.triggering_actor == 'chris-regnier')
     runs-on: macos-latest
     steps:
       - name: Checkout
@@ -92,7 +92,7 @@ jobs:
           retention-days: 5
 
   release:
-    if: github.event_name != 'workflow_dispatch' || github.actor == 'chris-regnier'
+    if: github.event_name != 'workflow_dispatch' || (github.actor == 'chris-regnier' && github.triggering_actor == 'chris-regnier')
     needs: [build-linux, build-macos]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
+          ref: ${{ env.TAG }}
           fetch-depth: 0
 
       - name: Set up Go
@@ -63,6 +64,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
+          ref: ${{ env.TAG }}
           fetch-depth: 0
 
       - name: Set up Go
@@ -97,6 +99,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
+          ref: ${{ env.TAG }}
           fetch-depth: 0
 
       - name: Download Linux artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,18 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Git tag to release (e.g. v0.6.0)'
+        required: true
+        type: string
 
 permissions:
   contents: write
+
+env:
+  TAG: ${{ inputs.tag || github.ref_name }}
 
 jobs:
   build-linux:
@@ -127,8 +136,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create ${{ github.ref_name }} \
-            --title "Gavel ${{ github.ref_name }}" \
+          gh release create ${{ env.TAG }} \
+            --title "Gavel ${{ env.TAG }}" \
             --notes-file CHANGELOG.md \
             dist/*.tar.gz \
             dist/checksums.txt

--- a/docs/superpowers/plans/2026-04-15-release-recovery.md
+++ b/docs/superpowers/plans/2026-04-15-release-recovery.md
@@ -1,0 +1,265 @@
+# Release Recovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the release workflow recoverable when one OS build leg fails, without deleting/re-pushing tags.
+
+**Architecture:** Add `workflow_dispatch` trigger with actor gate and bump artifact retention. All changes in one file.
+
+**Tech Stack:** GitHub Actions YAML
+
+---
+
+### Task 1: Add `workflow_dispatch` trigger and tag resolution
+
+**Files:**
+- Modify: `.github/workflows/release.yml:1-10`
+
+**Spec ref:** Sections 1, 3 of the design spec.
+
+- [ ] **Step 1: Add `workflow_dispatch` trigger with tag input**
+
+Replace the current `on:` block (lines 3-6):
+
+```yaml
+on:
+  push:
+    tags:
+      - 'v*'
+```
+
+With:
+
+```yaml
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Git tag to release (e.g. v0.6.0)'
+        required: true
+        type: string
+```
+
+- [ ] **Step 2: Add top-level `env` block for tag resolution**
+
+Add after the `permissions:` block (after line 9), before `jobs:`:
+
+```yaml
+env:
+  TAG: ${{ inputs.tag || github.ref_name }}
+```
+
+This resolves to the `workflow_dispatch` input when present, or the pushed tag ref otherwise.
+
+- [ ] **Step 3: Validate YAML syntax**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"`
+
+Expected: no output (valid YAML).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/release.yml
+git commit -m "ci(release): add workflow_dispatch trigger with tag input (#92)"
+```
+
+---
+
+### Task 2: Add actor gate to all jobs
+
+**Files:**
+- Modify: `.github/workflows/release.yml` (all three job definitions)
+
+**Spec ref:** Section 2 of the design spec.
+
+- [ ] **Step 1: Add `if` condition to `build-linux` job**
+
+Add immediately after the `build-linux:` job key, before `runs-on:`:
+
+```yaml
+  build-linux:
+    if: github.event_name != 'workflow_dispatch' || github.actor == 'chris-regnier'
+    runs-on: ubuntu-latest
+```
+
+- [ ] **Step 2: Add `if` condition to `build-macos` job**
+
+Add immediately after the `build-macos:` job key, before `runs-on:`:
+
+```yaml
+  build-macos:
+    if: github.event_name != 'workflow_dispatch' || github.actor == 'chris-regnier'
+    runs-on: macos-latest
+```
+
+- [ ] **Step 3: Add `if` condition to `release` job**
+
+Add immediately after the `release:` job key, before `needs:`. Note: when a job has both `if` and `needs`, `if` must come first for readability but the order doesn't matter to GitHub Actions. Place it before `needs:`:
+
+```yaml
+  release:
+    if: github.event_name != 'workflow_dispatch' || github.actor == 'chris-regnier'
+    needs: [build-linux, build-macos]
+```
+
+- [ ] **Step 4: Validate YAML syntax**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"`
+
+Expected: no output (valid YAML).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/release.yml
+git commit -m "ci(release): restrict workflow_dispatch to chris-regnier (#92)"
+```
+
+---
+
+### Task 3: Update checkout steps to use resolved tag
+
+**Files:**
+- Modify: `.github/workflows/release.yml` (all three checkout steps)
+
+**Spec ref:** Section 4 of the design spec.
+
+- [ ] **Step 1: Update `build-linux` checkout to use TAG**
+
+Change the checkout step in `build-linux` from:
+
+```yaml
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+```
+
+To:
+
+```yaml
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ env.TAG }}
+          fetch-depth: 0
+```
+
+- [ ] **Step 2: Update `build-macos` checkout to use TAG**
+
+Same change — add `ref: ${{ env.TAG }}` to the checkout step in `build-macos`:
+
+```yaml
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ env.TAG }}
+          fetch-depth: 0
+```
+
+- [ ] **Step 3: Update `release` checkout to use TAG**
+
+Same change — add `ref: ${{ env.TAG }}` to the checkout step in `release`:
+
+```yaml
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ env.TAG }}
+          fetch-depth: 0
+```
+
+- [ ] **Step 4: Validate YAML syntax**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"`
+
+Expected: no output (valid YAML).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/release.yml
+git commit -m "ci(release): checkout explicit tag ref for dispatch support (#92)"
+```
+
+---
+
+### Task 4: Update release step and bump artifact retention
+
+**Files:**
+- Modify: `.github/workflows/release.yml` (upload-artifact steps and gh release create)
+
+**Spec ref:** Sections 5, 6 of the design spec.
+
+- [ ] **Step 1: Update `gh release create` to use TAG env var**
+
+In the `release` job, change the `Create Release` step from:
+
+```yaml
+          gh release create ${{ github.ref_name }} \
+            --title "Gavel ${{ github.ref_name }}" \
+```
+
+To:
+
+```yaml
+          gh release create ${{ env.TAG }} \
+            --title "Gavel ${{ env.TAG }}" \
+```
+
+- [ ] **Step 2: Bump Linux artifact retention from 1 to 5 days**
+
+In `build-linux`, change:
+
+```yaml
+          retention-days: 1
+```
+
+To:
+
+```yaml
+          retention-days: 5
+```
+
+- [ ] **Step 3: Bump macOS artifact retention from 1 to 5 days**
+
+In `build-macos`, change:
+
+```yaml
+          retention-days: 1
+```
+
+To:
+
+```yaml
+          retention-days: 5
+```
+
+- [ ] **Step 4: Validate YAML syntax**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"`
+
+Expected: no output (valid YAML).
+
+- [ ] **Step 5: Final review — read the complete file and verify all changes are consistent**
+
+Run: `cat .github/workflows/release.yml`
+
+Verify:
+- `on:` block has both `push.tags` and `workflow_dispatch.inputs.tag`
+- Top-level `env.TAG` references `inputs.tag || github.ref_name`
+- All three jobs have the actor gate `if` condition
+- All three checkout steps have `ref: ${{ env.TAG }}`
+- `gh release create` uses `${{ env.TAG }}`
+- Both upload-artifact steps have `retention-days: 5`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .github/workflows/release.yml
+git commit -m "ci(release): use resolved tag and bump artifact retention to 5 days (#92)"
+```

--- a/docs/superpowers/specs/2026-04-13-release-recovery-design.md
+++ b/docs/superpowers/specs/2026-04-13-release-recovery-design.md
@@ -1,0 +1,75 @@
+# Release Recovery Design
+
+**Issue:** #92 — release: recover gracefully when one OS leg fails
+**Date:** 2026-04-13
+
+## Problem
+
+When one build leg (e.g. `build-linux`) fails during a release, the other leg's artifacts are uploaded but discarded because the `release` job depends on both. The only recovery path is deleting and re-pushing the tag.
+
+## Solution
+
+Two independent recovery paths, both achieved through changes to `release.yml`:
+
+1. **Fast path — "Re-run failed jobs":** Increase artifact retention from 1 day to 5 days so GitHub's built-in "Re-run failed jobs" button works reliably within a comfortable window (covers weekends).
+
+2. **Slow path — manual `workflow_dispatch`:** Add a `workflow_dispatch` trigger with a required `tag` input so the entire workflow can be re-triggered against any tag without deleting/re-pushing it. This covers the case where artifacts have already expired.
+
+## Changes to `release.yml`
+
+All changes are confined to `.github/workflows/release.yml`. No new files or jobs.
+
+### 1. Add `workflow_dispatch` trigger
+
+```yaml
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Git tag to release (e.g. v0.6.0)'
+        required: true
+        type: string
+```
+
+### 2. Actor gate on all jobs
+
+Restrict manual dispatch to `chris-regnier`:
+
+```yaml
+if: github.event_name != 'workflow_dispatch' || github.actor == 'chris-regnier'
+```
+
+Applied to all three jobs (`build-linux`, `build-macos`, `release`).
+
+### 3. Tag resolution
+
+Compute a single `TAG` value that works for both trigger types:
+
+```yaml
+env:
+  TAG: ${{ github.event.inputs.tag || github.ref_name }}
+```
+
+### 4. Checkout with explicit ref
+
+All checkout steps use `ref: ${{ env.TAG }}` to ensure manual dispatch builds the correct commit.
+
+### 5. Release step uses resolved tag
+
+`gh release create` uses `${{ env.TAG }}` instead of `${{ github.ref_name }}`.
+
+### 6. Artifact retention
+
+Bump `retention-days` from 1 to 5 on both `upload-artifact` steps.
+
+## Recovery Scenarios
+
+| Scenario | Action |
+|---|---|
+| One leg fails, noticed within 5 days | Click "Re-run failed jobs" in GitHub UI |
+| One leg fails, artifacts expired | Trigger workflow manually with the tag via Actions tab |
+| Both legs fail | Either re-run all jobs or trigger manually |
+| Unauthorized user tries manual dispatch | All jobs skip silently (actor gate) |


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` trigger with required `tag` input so the release workflow can be manually re-triggered against any tag without deleting/re-pushing it
- Restrict manual dispatch to `chris-regnier` via actor gate on all three jobs, hardened to check both `github.actor` and `github.triggering_actor` to prevent re-run impersonation
- Resolve a single `env.TAG` at the top level (`inputs.tag || github.ref_name`) used by checkouts and `gh release create`, so both trigger paths flow through the same value
- Bump artifact retention from 1 to 5 days so GitHub's built-in "Re-run failed jobs" button works across a weekend

## Recovery Paths
- **Fast path:** one leg fails, noticed within 5 days → click "Re-run failed jobs" in the GitHub UI. The successful leg's artifacts are still available.
- **Slow path:** artifacts expired, or failure discovered late → trigger the workflow manually via the Actions tab with the tag as input. Rebuilds everything cleanly against the same tag.

## Test Plan
- [ ] Merge this PR
- [ ] Cut a test tag (or wait for next release) and confirm the workflow triggers and publishes as before
- [ ] Simulate a failure (e.g., temporarily break one build) and verify "Re-run failed jobs" recovers correctly
- [ ] Trigger the workflow manually via Actions tab against an existing tag and confirm release publishes successfully
- [ ] Verify that a dispatch from a non-`chris-regnier` account skips all jobs cleanly

Closes #92

Design: `docs/superpowers/specs/2026-04-13-release-recovery-design.md`
Plan: `docs/superpowers/plans/2026-04-15-release-recovery.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)