### PR TITLE
feat(lsp): consume SARIF fixes as native WorkspaceEdit actions (#100)

### DIFF
--- a/internal/lsp/codeaction.go
+++ b/internal/lsp/codeaction.go
@@ -2,21 +2,50 @@
 package lsp
 
 import (
+	"path/filepath"
+	"strings"
+
 	"github.com/chris-regnier/gavel/internal/sarif"
 )
 
-// GetCodeActions returns code actions for the given diagnostics
+// GetCodeActions returns code actions for the given diagnostics.
+//
+// When a matching SARIF result carries structured Fixes, the action is emitted
+// as a native WorkspaceEdit so editors can apply it in one click. Otherwise it
+// falls back to a Command that surfaces the free-text recommendation.
 func GetCodeActions(uri string, diagnostics []Diagnostic, sarifResults []sarif.Result) []CodeAction {
 	var actions []CodeAction
 
 	for _, diag := range diagnostics {
-		// Find the corresponding SARIF result to get the recommendation
-		recommendation := findRecommendation(diag, sarifResults)
+		result := findMatchingResult(diag, sarifResults)
+
+		if result != nil && len(result.Fixes) > 0 {
+			for _, fix := range result.Fixes {
+				edit := buildWorkspaceEdit(uri, fix)
+				if edit == nil {
+					continue
+				}
+				title := fixTitle(fix, result, diag)
+				if title == "" {
+					continue
+				}
+				actions = append(actions, CodeAction{
+					Title:       "Gavel: " + truncateTitle(title, 60),
+					Kind:        CodeActionKindQuickFix,
+					Diagnostics: []Diagnostic{diag},
+					IsPreferred: true,
+					Edit:        edit,
+				})
+			}
+			continue
+		}
+
+		recommendation := recommendationFor(result, diag)
 		if recommendation == "" {
 			continue
 		}
 
-		action := CodeAction{
+		actions = append(actions, CodeAction{
 			Title:       "Gavel: " + truncateTitle(recommendation, 60),
 			Kind:        CodeActionKindQuickFix,
 			Diagnostics: []Diagnostic{diag},
@@ -29,21 +58,20 @@ func GetCodeActions(uri string, diagnostics []Diagnostic, sarifResults []sarif.R
 					recommendation,
 				},
 			},
-		}
-		actions = append(actions, action)
+		})
 	}
 
 	return actions
 }
 
-// findRecommendation finds the recommendation for a diagnostic from SARIF results
-func findRecommendation(diag Diagnostic, results []sarif.Result) string {
-	for _, r := range results {
+// findMatchingResult returns the SARIF result whose rule and primary line
+// match the diagnostic, or nil if none matches.
+func findMatchingResult(diag Diagnostic, results []sarif.Result) *sarif.Result {
+	for i := range results {
+		r := &results[i]
 		if r.RuleID != diag.Code {
 			continue
 		}
-
-		// Check if line matches
 		if len(r.Locations) > 0 {
 			region := r.Locations[0].PhysicalLocation.Region
 			// SARIF is 1-indexed, LSP diagnostic range is 0-indexed
@@ -51,21 +79,141 @@ func findRecommendation(diag Diagnostic, results []sarif.Result) string {
 				continue
 			}
 		}
+		return r
+	}
+	return nil
+}
 
-		// Extract recommendation from properties
-		if r.Properties != nil {
-			if rec, ok := r.Properties["gavel/recommendation"].(string); ok {
-				return rec
-			}
+// recommendationFor pulls the free-text recommendation from a SARIF result or
+// from the diagnostic's data field.
+func recommendationFor(result *sarif.Result, diag Diagnostic) string {
+	if result != nil && result.Properties != nil {
+		if rec, ok := result.Properties["gavel/recommendation"].(string); ok && rec != "" {
+			return rec
 		}
 	}
-
-	// Fall back to diagnostic data if available
 	if diag.Data != nil && diag.Data.Recommendation != "" {
 		return diag.Data.Recommendation
 	}
-
 	return ""
+}
+
+// fixTitle picks the best human-readable title for an edit-bearing action,
+// preferring the Fix's structured description over generic fallbacks.
+func fixTitle(fix sarif.Fix, result *sarif.Result, diag Diagnostic) string {
+	if fix.Description.Text != "" {
+		return fix.Description.Text
+	}
+	if rec := recommendationFor(result, diag); rec != "" {
+		return rec
+	}
+	if diag.Message != "" {
+		return diag.Message
+	}
+	return diag.Code
+}
+
+// buildWorkspaceEdit converts a SARIF Fix into an LSP WorkspaceEdit, grouping
+// replacements by their target file URI. Returns nil if the fix has no
+// applicable replacements.
+func buildWorkspaceEdit(documentURI string, fix sarif.Fix) *WorkspaceEdit {
+	changes := make(map[string][]TextEdit)
+	for _, change := range fix.ArtifactChanges {
+		targetURI := resolveArtifactURI(documentURI, change.ArtifactLocation.URI)
+		if targetURI == "" {
+			continue
+		}
+		for _, repl := range change.Replacements {
+			edit := TextEdit{
+				Range: sarifRegionToLSPRange(repl.DeletedRegion),
+			}
+			if repl.InsertedContent != nil {
+				edit.NewText = repl.InsertedContent.Text
+			}
+			changes[targetURI] = append(changes[targetURI], edit)
+		}
+	}
+	if len(changes) == 0 {
+		return nil
+	}
+	return &WorkspaceEdit{Changes: changes}
+}
+
+// sarifRegionToLSPRange converts a 1-indexed SARIF Region into a 0-indexed LSP
+// Range. When column information is absent (which is currently always the case
+// in Gavel's SARIF output), the range starts at column 0 and ends at column 0
+// of the following line, which selects the full last line per LSP semantics.
+func sarifRegionToLSPRange(region sarif.Region) Range {
+	startLine := region.StartLine - 1
+	if startLine < 0 {
+		startLine = 0
+	}
+
+	endLine := region.EndLine
+	if endLine <= 0 {
+		// No explicit end line: treat as a single-line region.
+		endLine = region.StartLine
+	}
+	if endLine < 1 {
+		endLine = 1
+	}
+
+	return Range{
+		Start: Position{Line: startLine, Character: 0},
+		End:   Position{Line: endLine, Character: 0},
+	}
+}
+
+// resolveArtifactURI maps a SARIF ArtifactLocation.URI to an LSP file URI,
+// using the active document URI as context for relative paths.
+//
+// Rules:
+//   - Empty artifact URI → reuse the document URI (the common single-file case).
+//   - Already a `file://` URI → return as-is.
+//   - Otherwise, if the artifact path matches the document's path (by suffix),
+//     reuse the document URI verbatim so editors don't see a divergent URI.
+//   - Absolute paths get a `file://` prefix.
+//   - Relative paths are resolved against the document URI's directory.
+func resolveArtifactURI(documentURI, artifactURI string) string {
+	if artifactURI == "" {
+		return documentURI
+	}
+	if strings.HasPrefix(artifactURI, "file://") {
+		return artifactURI
+	}
+
+	docPath := uriToPath(documentURI)
+	if docPath != "" && pathsMatch(docPath, artifactURI) {
+		return documentURI
+	}
+
+	if filepath.IsAbs(artifactURI) {
+		return "file://" + artifactURI
+	}
+
+	if docPath == "" {
+		return ""
+	}
+	resolved := filepath.Join(filepath.Dir(docPath), artifactURI)
+	return "file://" + resolved
+}
+
+// pathsMatch reports whether two paths refer to the same file. It accepts
+// either an exact match or a suffix match (covering cases where SARIF carries
+// a relative path while the document URI is absolute).
+func pathsMatch(docPath, artifactPath string) bool {
+	if docPath == artifactPath {
+		return true
+	}
+	if filepath.IsAbs(artifactPath) {
+		return false
+	}
+	cleanDoc := filepath.Clean(docPath)
+	cleanArt := filepath.Clean(artifactPath)
+	if strings.HasSuffix(cleanDoc, string(filepath.Separator)+cleanArt) {
+		return true
+	}
+	return filepath.Base(cleanDoc) == cleanArt
 }
 
 // truncateTitle truncates a string to maxLen, adding ellipsis if needed

--- a/internal/lsp/codeaction_test.go
+++ b/internal/lsp/codeaction_test.go
@@ -2,6 +2,7 @@
 package lsp
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/chris-regnier/gavel/internal/sarif"
@@ -14,16 +15,18 @@ func TestGetCodeActions(t *testing.T) {
 		diagnostics []Diagnostic
 		results     []sarif.Result
 		wantCount   int
+		wantCommand bool
+		wantEdit    bool
 	}{
 		{
-			name: "no diagnostics",
-			uri:  "file:///test.go",
+			name:        "no diagnostics",
+			uri:         "file:///test.go",
 			diagnostics: []Diagnostic{},
 			results:     []sarif.Result{},
 			wantCount:   0,
 		},
 		{
-			name: "diagnostic with recommendation",
+			name: "diagnostic with recommendation falls back to command",
 			uri:  "file:///test.go",
 			diagnostics: []Diagnostic{
 				{
@@ -39,7 +42,7 @@ func TestGetCodeActions(t *testing.T) {
 					Level:  "warning",
 					Locations: []sarif.Location{{
 						PhysicalLocation: sarif.PhysicalLocation{
-							Region: sarif.Region{StartLine: 11}, // 1-indexed
+							Region: sarif.Region{StartLine: 11},
 						},
 					}},
 					Properties: map[string]interface{}{
@@ -47,10 +50,11 @@ func TestGetCodeActions(t *testing.T) {
 					},
 				},
 			},
-			wantCount: 1,
+			wantCount:   1,
+			wantCommand: true,
 		},
 		{
-			name: "diagnostic without recommendation",
+			name: "diagnostic without recommendation produces no action",
 			uri:  "file:///test.go",
 			diagnostics: []Diagnostic{
 				{
@@ -75,7 +79,7 @@ func TestGetCodeActions(t *testing.T) {
 			wantCount: 0,
 		},
 		{
-			name: "diagnostic with recommendation in Data field",
+			name: "diagnostic with recommendation in Data field falls back to command",
 			uri:  "file:///test.go",
 			diagnostics: []Diagnostic{
 				{
@@ -88,8 +92,50 @@ func TestGetCodeActions(t *testing.T) {
 					},
 				},
 			},
-			results: []sarif.Result{},
+			results:     []sarif.Result{},
+			wantCount:   1,
+			wantCommand: true,
+		},
+		{
+			name: "diagnostic with structured Fix produces WorkspaceEdit",
+			uri:  "file:///workspace/config.go",
+			diagnostics: []Diagnostic{
+				{
+					Range:    Range{Start: Position{Line: 41}, End: Position{Line: 41}},
+					Code:     "S2068",
+					Message:  "Hardcoded credential",
+					Severity: DiagnosticSeverityError,
+				},
+			},
+			results: []sarif.Result{
+				{
+					RuleID: "S2068",
+					Level:  "error",
+					Locations: []sarif.Location{{
+						PhysicalLocation: sarif.PhysicalLocation{
+							ArtifactLocation: sarif.ArtifactLocation{URI: "config.go"},
+							Region:           sarif.Region{StartLine: 42},
+						},
+					}},
+					Properties: map[string]interface{}{
+						"gavel/recommendation": "Replace hardcoded credential",
+					},
+					Fixes: []sarif.Fix{{
+						Description: sarif.Message{Text: "Use environment variable"},
+						ArtifactChanges: []sarif.ArtifactChange{{
+							ArtifactLocation: sarif.ArtifactLocation{URI: "config.go"},
+							Replacements: []sarif.Replacement{{
+								DeletedRegion: sarif.Region{StartLine: 42, EndLine: 42},
+								InsertedContent: &sarif.ArtifactContent{
+									Text: `os.Getenv("DB_PASSWORD")`,
+								},
+							}},
+						}},
+					}},
+				},
+			},
 			wantCount: 1,
+			wantEdit:  true,
 		},
 	}
 
@@ -100,14 +146,241 @@ func TestGetCodeActions(t *testing.T) {
 				t.Errorf("GetCodeActions() returned %d actions, want %d", len(actions), tt.wantCount)
 			}
 
-			// Verify action properties if we got actions
 			for _, action := range actions {
 				if action.Kind != CodeActionKindQuickFix {
 					t.Errorf("Action kind = %s, want %s", action.Kind, CodeActionKindQuickFix)
 				}
-				if action.Command == nil {
+				if tt.wantCommand && action.Command == nil {
 					t.Error("Action should have a command")
 				}
+				if tt.wantEdit {
+					if action.Edit == nil {
+						t.Fatal("Action should have an edit")
+					}
+					if action.Command != nil {
+						t.Error("Action with edit should not also carry a command")
+					}
+					if !action.IsPreferred {
+						t.Error("Edit-bearing action should be marked IsPreferred")
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestGetCodeActions_FixTitlePrefersDescription(t *testing.T) {
+	uri := "file:///workspace/main.go"
+	diagnostics := []Diagnostic{{
+		Range:   Range{Start: Position{Line: 9}, End: Position{Line: 9}},
+		Code:    "RULE1",
+		Message: "Issue",
+	}}
+	results := []sarif.Result{{
+		RuleID: "RULE1",
+		Locations: []sarif.Location{{
+			PhysicalLocation: sarif.PhysicalLocation{
+				ArtifactLocation: sarif.ArtifactLocation{URI: "main.go"},
+				Region:           sarif.Region{StartLine: 10},
+			},
+		}},
+		Properties: map[string]interface{}{
+			"gavel/recommendation": "Generic recommendation text",
+		},
+		Fixes: []sarif.Fix{{
+			Description: sarif.Message{Text: "Specific fix description"},
+			ArtifactChanges: []sarif.ArtifactChange{{
+				ArtifactLocation: sarif.ArtifactLocation{URI: "main.go"},
+				Replacements: []sarif.Replacement{{
+					DeletedRegion:   sarif.Region{StartLine: 10, EndLine: 10},
+					InsertedContent: &sarif.ArtifactContent{Text: "newCode"},
+				}},
+			}},
+		}},
+	}}
+
+	actions := GetCodeActions(uri, diagnostics, results)
+	if len(actions) != 1 {
+		t.Fatalf("expected 1 action, got %d", len(actions))
+	}
+	if !strings.Contains(actions[0].Title, "Specific fix description") {
+		t.Errorf("title %q should derive from Fix.Description, not the recommendation", actions[0].Title)
+	}
+}
+
+func TestGetCodeActions_FixWithoutDescriptionUsesRecommendation(t *testing.T) {
+	uri := "file:///workspace/main.go"
+	diagnostics := []Diagnostic{{
+		Range: Range{Start: Position{Line: 9}, End: Position{Line: 9}},
+		Code:  "RULE1",
+	}}
+	results := []sarif.Result{{
+		RuleID: "RULE1",
+		Locations: []sarif.Location{{
+			PhysicalLocation: sarif.PhysicalLocation{
+				ArtifactLocation: sarif.ArtifactLocation{URI: "main.go"},
+				Region:           sarif.Region{StartLine: 10},
+			},
+		}},
+		Properties: map[string]interface{}{
+			"gavel/recommendation": "Use the recommendation",
+		},
+		Fixes: []sarif.Fix{{
+			ArtifactChanges: []sarif.ArtifactChange{{
+				ArtifactLocation: sarif.ArtifactLocation{URI: "main.go"},
+				Replacements: []sarif.Replacement{{
+					DeletedRegion:   sarif.Region{StartLine: 10, EndLine: 10},
+					InsertedContent: &sarif.ArtifactContent{Text: "x"},
+				}},
+			}},
+		}},
+	}}
+
+	actions := GetCodeActions(uri, diagnostics, results)
+	if len(actions) != 1 {
+		t.Fatalf("expected 1 action, got %d", len(actions))
+	}
+	if !strings.Contains(actions[0].Title, "Use the recommendation") {
+		t.Errorf("title %q should fall back to the recommendation when description is empty", actions[0].Title)
+	}
+}
+
+func TestBuildWorkspaceEdit_MultiFile(t *testing.T) {
+	docURI := "file:///workspace/handler.go"
+	fix := sarif.Fix{
+		ArtifactChanges: []sarif.ArtifactChange{
+			{
+				ArtifactLocation: sarif.ArtifactLocation{URI: "handler.go"},
+				Replacements: []sarif.Replacement{{
+					DeletedRegion:   sarif.Region{StartLine: 5, EndLine: 5},
+					InsertedContent: &sarif.ArtifactContent{Text: "sanitized"},
+				}},
+			},
+			{
+				ArtifactLocation: sarif.ArtifactLocation{URI: "/workspace/db/query.go"},
+				Replacements: []sarif.Replacement{{
+					DeletedRegion:   sarif.Region{StartLine: 12, EndLine: 12},
+					InsertedContent: &sarif.ArtifactContent{Text: "?"},
+				}},
+			},
+		},
+	}
+
+	edit := buildWorkspaceEdit(docURI, fix)
+	if edit == nil {
+		t.Fatal("expected non-nil WorkspaceEdit")
+	}
+	if len(edit.Changes) != 2 {
+		t.Fatalf("expected 2 file entries, got %d: %v", len(edit.Changes), keys(edit.Changes))
+	}
+	if _, ok := edit.Changes[docURI]; !ok {
+		t.Errorf("expected document URI %q in Changes, got %v", docURI, keys(edit.Changes))
+	}
+	if _, ok := edit.Changes["file:///workspace/db/query.go"]; !ok {
+		t.Errorf("expected absolute artifact URI to be promoted to file:// URI, got %v", keys(edit.Changes))
+	}
+}
+
+func TestSarifRegionToLSPRange(t *testing.T) {
+	tests := []struct {
+		name   string
+		region sarif.Region
+		want   Range
+	}{
+		{
+			name:   "single line",
+			region: sarif.Region{StartLine: 42, EndLine: 42},
+			want: Range{
+				Start: Position{Line: 41, Character: 0},
+				End:   Position{Line: 42, Character: 0},
+			},
+		},
+		{
+			name:   "multi-line",
+			region: sarif.Region{StartLine: 10, EndLine: 15},
+			want: Range{
+				Start: Position{Line: 9, Character: 0},
+				End:   Position{Line: 15, Character: 0},
+			},
+		},
+		{
+			name:   "missing end line collapses to start",
+			region: sarif.Region{StartLine: 5},
+			want: Range{
+				Start: Position{Line: 4, Character: 0},
+				End:   Position{Line: 5, Character: 0},
+			},
+		},
+		{
+			name:   "zero start clamps to first line",
+			region: sarif.Region{StartLine: 0, EndLine: 1},
+			want: Range{
+				Start: Position{Line: 0, Character: 0},
+				End:   Position{Line: 1, Character: 0},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sarifRegionToLSPRange(tt.region)
+			if got != tt.want {
+				t.Errorf("sarifRegionToLSPRange(%+v) = %+v, want %+v", tt.region, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveArtifactURI(t *testing.T) {
+	tests := []struct {
+		name        string
+		documentURI string
+		artifactURI string
+		want        string
+	}{
+		{
+			name:        "empty artifact URI reuses document",
+			documentURI: "file:///workspace/main.go",
+			artifactURI: "",
+			want:        "file:///workspace/main.go",
+		},
+		{
+			name:        "already a file URI returned verbatim",
+			documentURI: "file:///workspace/main.go",
+			artifactURI: "file:///elsewhere/other.go",
+			want:        "file:///elsewhere/other.go",
+		},
+		{
+			name:        "matching basename reuses document URI",
+			documentURI: "file:///workspace/main.go",
+			artifactURI: "main.go",
+			want:        "file:///workspace/main.go",
+		},
+		{
+			name:        "matching subpath reuses document URI",
+			documentURI: "file:///workspace/pkg/main.go",
+			artifactURI: "pkg/main.go",
+			want:        "file:///workspace/pkg/main.go",
+		},
+		{
+			name:        "absolute path gets file:// prefix",
+			documentURI: "file:///workspace/main.go",
+			artifactURI: "/other/path/util.go",
+			want:        "file:///other/path/util.go",
+		},
+		{
+			name:        "relative path resolves against document directory",
+			documentURI: "file:///workspace/pkg/main.go",
+			artifactURI: "../util/helper.go",
+			want:        "file:///workspace/util/helper.go",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveArtifactURI(tt.documentURI, tt.artifactURI)
+			if got != tt.want {
+				t.Errorf("resolveArtifactURI(%q, %q) = %q, want %q", tt.documentURI, tt.artifactURI, got, tt.want)
 			}
 		})
 	}
@@ -179,4 +452,12 @@ func TestTruncateTitle(t *testing.T) {
 			}
 		})
 	}
+}
+
+func keys(m map[string][]TextEdit) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
 }


### PR DESCRIPTION
When a SARIF result carries a structured Fix, emit a code action with a
populated WorkspaceEdit and IsPreferred set, so editors can apply the
remediation in one click. Falls back to the existing command-based
action that surfaces the free-text recommendation when no Fix is
available.

- Maps 1-indexed SARIF Region to 0-indexed LSP Range, defaulting to the
  start of the following line for end-of-line column semantics.
- Resolves SARIF ArtifactLocation.URI to an LSP file URI: reuses the
  document URI for matching paths, prefixes absolute paths with file://,
  and resolves relative paths against the document directory.
- Action title prefers Fix.Description.Text, falling back to the
  recommendation, then the diagnostic message or rule code.