### PR TITLE
mcp: route analyze handlers through AnalyzeService (#106)

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -20,7 +20,7 @@ import (
 	"github.com/chris-regnier/gavel/internal/evaluator"
 	"github.com/chris-regnier/gavel/internal/input"
 	"github.com/chris-regnier/gavel/internal/rules"
-	"github.com/chris-regnier/gavel/internal/sarif"
+	"github.com/chris-regnier/gavel/internal/service"
 	"github.com/chris-regnier/gavel/internal/store"
 	"github.com/chris-regnier/gavel/internal/suppression"
 )
@@ -46,10 +46,17 @@ func NewMCPServer(cfg ServerConfig) *server.MCPServer {
 		server.WithPromptCapabilities(true),
 	)
 
+	// Build the BAML client once at startup (matching previous behavior)
+	// and feed it to the AnalyzeService via a factory closure so the same
+	// client serves every analyze_* tool call.
+	client := analyzer.NewBAMLLiveClient(cfg.Config.Provider)
+	analyzeSvc := service.NewAnalyzeService(cfg.Store).WithClientFactory(
+		func(_ config.ProviderConfig) analyzer.BAMLClient { return client },
+	)
+
 	h := &handlers{
-		cfg:    cfg,
-		client: analyzer.NewBAMLLiveClient(cfg.Config.Provider),
-		rules:  cfg.Rules,
+		cfg:        cfg,
+		analyzeSvc: analyzeSvc,
 	}
 
 	// Register tools
@@ -76,10 +83,11 @@ func NewMCPServer(cfg ServerConfig) *server.MCPServer {
 }
 
 // handlers holds the server config and implements all tool/resource/prompt handlers.
+// All analyze_* tools route through analyzeSvc so MCP, CLI, and the HTTP
+// service share a single orchestration entrypoint (see issue #106).
 type handlers struct {
-	cfg    ServerConfig
-	client analyzer.BAMLClient
-	rules  []rules.Rule
+	cfg        ServerConfig
+	analyzeSvc *service.AnalyzeService
 }
 
 // --- Tool definitions ---
@@ -252,48 +260,6 @@ func architectureReviewPrompt() mcp.Prompt {
 	)
 }
 
-// baselineCounts summarizes how many results fell into each baselineState
-// bucket after CompareBaseline was applied. An empty value means no
-// baseline comparison was performed.
-type baselineCounts struct {
-	Source    string `json:"source"`
-	New       int    `json:"new"`
-	Unchanged int    `json:"unchanged"`
-	Absent    int    `json:"absent"`
-}
-
-// applyBaseline stamps automation details onto sarifLog and, when the
-// `baseline` tool parameter is set, loads that baseline and annotates
-// each result with a baselineState. Returns the bucket counts so the
-// handler can include them in its summary, or a CallToolResult error if
-// the baseline failed to load.
-func (h *handlers) applyBaseline(ctx context.Context, sarifLog *sarif.Log, baseline string) (baselineCounts, *mcp.CallToolResult) {
-	sarif.EnsureAutomationDetails(sarifLog)
-	if baseline == "" {
-		return baselineCounts{}, nil
-	}
-	baselineLog, err := store.LoadBaseline(ctx, h.cfg.Store, baseline)
-	if err != nil {
-		return baselineCounts{}, mcp.NewToolResultError(fmt.Sprintf("loading baseline %q: %v", baseline, err))
-	}
-	sarif.CompareBaseline(sarifLog, baselineLog)
-
-	counts := baselineCounts{Source: baseline}
-	if len(sarifLog.Runs) > 0 {
-		for _, r := range sarifLog.Runs[0].Results {
-			switch r.BaselineState {
-			case sarif.BaselineStateNew:
-				counts.New++
-			case sarif.BaselineStateUnchanged:
-				counts.Unchanged++
-			case sarif.BaselineStateAbsent:
-				counts.Absent++
-			}
-		}
-	}
-	return counts, nil
-}
-
 // --- Tool handlers ---
 
 func (h *handlers) handleAnalyzeFile(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -306,61 +272,34 @@ func (h *handlers) handleAnalyzeFile(ctx context.Context, request mcp.CallToolRe
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	persona := request.GetString("persona", h.cfg.Config.Persona)
-	if persona == "" {
-		persona = "code-reviewer"
-	}
-
+	persona := h.resolvePersona(request)
 	baseline := request.GetString("baseline", "")
 
-	// Read the file
 	content, err := os.ReadFile(path)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("reading file: %v", err)), nil
 	}
 
-	// Run analysis
-	results, err := h.runAnalysis(ctx, []input.Artifact{{Path: path, Content: string(content)}}, persona)
+	req := h.analyzeRequest(persona, baseline, []input.Artifact{
+		{Path: path, Content: string(content), Kind: input.KindFile},
+	})
+
+	result, err := h.analyzeSvc.Analyze(ctx, req)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("analysis failed: %v", err)), nil
 	}
 
-	// Build SARIF and store so judge can evaluate later
-	descriptors := buildDescriptors(h.cfg.Config.Policies, h.rules)
-	sarifLog := sarif.Assemble(results, descriptors, "file", persona)
-
-	baselineSummary, errResult := h.applyBaseline(ctx, sarifLog, baseline)
-	if errResult != nil {
-		return errResult, nil
-	}
-
-	supps, loadErr := suppression.Load(h.rootDir())
-	if loadErr != nil {
-		slog.Warn("failed to load suppressions", "err", loadErr)
-	}
-	suppression.Apply(supps, sarifLog)
-
-	id, err := h.cfg.Store.WriteSARIF(ctx, sarifLog)
-	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("storing results: %v", err)), nil
-	}
-
 	summary := map[string]interface{}{
-		"id":       id,
-		"findings": len(results),
+		"id":       result.ResultID,
+		"findings": result.TotalFindings,
 		"files":    1,
 		"persona":  persona,
 		"path":     path,
 	}
 	if baseline != "" {
-		summary["baseline"] = baselineSummary
+		summary["baseline"] = result.Baseline
 	}
-	out, err := json.MarshalIndent(summary, "", "  ")
-	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("marshaling summary: %v", err)), nil
-	}
-
-	return mcp.NewToolResultText(string(out)), nil
+	return marshalSummary(summary)
 }
 
 func (h *handlers) handleAnalyzeDirectory(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -373,14 +312,9 @@ func (h *handlers) handleAnalyzeDirectory(ctx context.Context, request mcp.CallT
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	persona := request.GetString("persona", h.cfg.Config.Persona)
-	if persona == "" {
-		persona = "code-reviewer"
-	}
-
+	persona := h.resolvePersona(request)
 	baseline := request.GetString("baseline", "")
 
-	// Read directory
 	handler := input.NewHandler()
 	artifacts, err := handler.ReadDirectory(dir)
 	if err != nil {
@@ -391,47 +325,23 @@ func (h *handlers) handleAnalyzeDirectory(ctx context.Context, request mcp.CallT
 		return mcp.NewToolResultText("No supported files found in directory."), nil
 	}
 
-	// Run analysis
-	results, err := h.runAnalysis(ctx, artifacts, persona)
+	req := h.analyzeRequest(persona, baseline, artifacts)
+
+	result, err := h.analyzeSvc.Analyze(ctx, req)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("analysis failed: %v", err)), nil
 	}
 
-	// Build SARIF and store
-	descriptors := buildDescriptors(h.cfg.Config.Policies, h.rules)
-	sarifLog := sarif.Assemble(results, descriptors, "directory", persona)
-
-	baselineSummary, errResult := h.applyBaseline(ctx, sarifLog, baseline)
-	if errResult != nil {
-		return errResult, nil
-	}
-
-	supps, loadErr := suppression.Load(h.rootDir())
-	if loadErr != nil {
-		slog.Warn("failed to load suppressions", "err", loadErr)
-	}
-	suppression.Apply(supps, sarifLog)
-
-	id, err := h.cfg.Store.WriteSARIF(ctx, sarifLog)
-	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("storing results: %v", err)), nil
-	}
-
 	summary := map[string]interface{}{
-		"id":       id,
-		"findings": len(results),
+		"id":       result.ResultID,
+		"findings": result.TotalFindings,
 		"files":    len(artifacts),
 		"persona":  persona,
 	}
 	if baseline != "" {
-		summary["baseline"] = baselineSummary
+		summary["baseline"] = result.Baseline
 	}
-	out, err := json.MarshalIndent(summary, "", "  ")
-	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("marshaling summary: %v", err)), nil
-	}
-
-	return mcp.NewToolResultText(string(out)), nil
+	return marshalSummary(summary)
 }
 
 func (h *handlers) handleJudge(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -558,20 +468,14 @@ func (h *handlers) handleAnalyzeDiff(ctx context.Context, request mcp.CallToolRe
 		return mcp.NewToolResultError("line_start must be <= line_end"), nil
 	}
 
-	persona := request.GetString("persona", h.cfg.Config.Persona)
-	if persona == "" {
-		persona = "code-reviewer"
-	}
-
+	persona := h.resolvePersona(request)
 	baseline := request.GetString("baseline", "")
 
-	// Read the full file
 	content, err := os.ReadFile(path)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("reading file: %v", err)), nil
 	}
 
-	// Determine changed line range
 	var changedStart, changedEnd int
 	if hasDiff {
 		changedStart, changedEnd = extractChangedLines(diffText)
@@ -583,112 +487,34 @@ func (h *handlers) handleAnalyzeDiff(ctx context.Context, request mcp.CallToolRe
 		changedEnd = lineEnd
 	}
 
-	lines := strings.Split(string(content), "\n")
-	totalLines := len(lines)
-
-	// Extract scoped content with 10-line context window
-	contextWindow := 10
-	scopeStart := changedStart - contextWindow
-	if scopeStart < 1 {
-		scopeStart = 1
-	}
-	scopeEnd := changedEnd + contextWindow
-	if scopeEnd > totalLines {
-		scopeEnd = totalLines
+	cfg := h.configWithPersona(persona)
+	scopedReq := service.ScopedAnalyzeRequest{
+		Artifact:       input.Artifact{Path: path, Content: string(content), Kind: input.KindFile},
+		ChangedStart:   changedStart,
+		ChangedEnd:     changedEnd,
+		Config:         cfg,
+		Rules:          h.cfg.Rules,
+		BaselineID:     baseline,
+		SuppressionDir: h.rootDir(),
 	}
 
-	// Build scoped content (scopeStart and scopeEnd are 1-indexed)
-	scopedLines := lines[scopeStart-1 : scopeEnd]
-	scopedContent := strings.Join(scopedLines, "\n")
-
-	// Run instant tier on full file, filter findings to changed lines.
-	// Pass loaded rules so custom rules fire alongside embedded defaults.
-	fullArtifact := input.Artifact{Path: path, Content: string(content), Kind: input.KindFile}
-	instantOpts := []analyzer.TieredAnalyzerOption{}
-	if len(h.rules) > 0 {
-		instantOpts = append(instantOpts, analyzer.WithInstantPatterns(h.rules))
-	}
-	ta := analyzer.NewTieredAnalyzer(h.client, instantOpts...)
-	instantResults := ta.RunPatternMatching(fullArtifact)
-
-	var filteredInstant []sarif.Result
-	for _, r := range instantResults {
-		if len(r.Locations) > 0 {
-			region := r.Locations[0].PhysicalLocation.Region
-			if region.StartLine >= changedStart && region.StartLine <= changedEnd {
-				filteredInstant = append(filteredInstant, r)
-			}
-		}
-	}
-
-	// Run comprehensive tier on scoped content
-	scopedArtifact := []input.Artifact{{Path: path, Content: scopedContent, Kind: input.KindFile}}
-	comprehensiveResults, err := h.runAnalysis(ctx, scopedArtifact, persona)
+	result, err := h.analyzeSvc.AnalyzeScoped(ctx, scopedReq)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("analysis failed: %v", err)), nil
 	}
 
-	// Adjust comprehensive tier line numbers (add scopeStart offset)
-	// The LLM sees scopedContent starting at line 1, but it's actually at scopeStart
-	offset := scopeStart - 1
-	for i := range comprehensiveResults {
-		if len(comprehensiveResults[i].Locations) > 0 {
-			comprehensiveResults[i].Locations[0].PhysicalLocation.Region.StartLine += offset
-			comprehensiveResults[i].Locations[0].PhysicalLocation.Region.EndLine += offset
-		}
-	}
-
-	// Filter comprehensive results to changed lines
-	var filteredComprehensive []sarif.Result
-	for _, r := range comprehensiveResults {
-		if len(r.Locations) > 0 {
-			region := r.Locations[0].PhysicalLocation.Region
-			if region.StartLine >= changedStart && region.StartLine <= changedEnd {
-				filteredComprehensive = append(filteredComprehensive, r)
-			}
-		}
-	}
-
-	// Combine all filtered results
-	allResults := append(filteredInstant, filteredComprehensive...)
-
-	// Build SARIF, apply suppressions, store, return summary
-	descriptors := buildDescriptors(h.cfg.Config.Policies, h.rules)
-	sarifLog := sarif.Assemble(allResults, descriptors, "diff", persona)
-
-	baselineSummary, errResult := h.applyBaseline(ctx, sarifLog, baseline)
-	if errResult != nil {
-		return errResult, nil
-	}
-
-	supps, loadErr := suppression.Load(h.rootDir())
-	if loadErr != nil {
-		slog.Warn("failed to load suppressions", "err", loadErr)
-	}
-	suppression.Apply(supps, sarifLog)
-
-	id, err := h.cfg.Store.WriteSARIF(ctx, sarifLog)
-	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("storing results: %v", err)), nil
-	}
-
 	summary := map[string]interface{}{
-		"id":            id,
-		"findings":      len(allResults),
+		"id":            result.ResultID,
+		"findings":      result.TotalFindings,
 		"path":          path,
 		"persona":       persona,
 		"changed_start": changedStart,
 		"changed_end":   changedEnd,
 	}
 	if baseline != "" {
-		summary["baseline"] = baselineSummary
+		summary["baseline"] = result.Baseline
 	}
-	out, err := json.MarshalIndent(summary, "", "  ")
-	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("marshaling summary: %v", err)), nil
-	}
-
-	return mcp.NewToolResultText(string(out)), nil
+	return marshalSummary(summary)
 }
 
 // extractChangedLines parses a unified diff and returns the overall range of changed lines.
@@ -992,29 +818,47 @@ func (h *handlers) buildAnalysisPrompt(request mcp.GetPromptRequest, persona, in
 
 // --- Helpers ---
 
-func (h *handlers) runAnalysis(ctx context.Context, artifacts []input.Artifact, persona string) ([]sarif.Result, error) {
-	personaPrompt, err := analyzer.GetPersonaPrompt(ctx, persona)
+// resolvePersona returns the persona to use for a tool call: the
+// `persona` arg if supplied, then the configured persona, then the
+// hardcoded "code-reviewer" default. Mirrors the behavior of every
+// analyze_* MCP handler.
+func (h *handlers) resolvePersona(request mcp.CallToolRequest) string {
+	persona := request.GetString("persona", h.cfg.Config.Persona)
+	if persona == "" {
+		persona = "code-reviewer"
+	}
+	return persona
+}
+
+// configWithPersona returns a copy of the server config with Persona
+// overridden so the AnalyzeService picks up the per-tool-call selection.
+func (h *handlers) configWithPersona(persona string) config.Config {
+	cfg := *h.cfg.Config
+	cfg.Persona = persona
+	return cfg
+}
+
+// analyzeRequest builds an AnalyzeRequest from the server config plus
+// per-call inputs. Suppressions are wired through so the service stamps
+// matching .gavel/suppressions.yaml entries before storage.
+func (h *handlers) analyzeRequest(persona, baseline string, artifacts []input.Artifact) service.AnalyzeRequest {
+	return service.AnalyzeRequest{
+		Artifacts:      artifacts,
+		Config:         h.configWithPersona(persona),
+		Rules:          h.cfg.Rules,
+		BaselineID:     baseline,
+		SuppressionDir: h.rootDir(),
+	}
+}
+
+// marshalSummary serializes summary as indented JSON wrapped in an MCP
+// tool result, mapping marshal errors to MCP error results.
+func marshalSummary(summary map[string]interface{}) (*mcp.CallToolResult, error) {
+	out, err := json.MarshalIndent(summary, "", "  ")
 	if err != nil {
-		return nil, fmt.Errorf("loading persona %s: %w", persona, err)
+		return mcp.NewToolResultError(fmt.Sprintf("marshaling summary: %v", err)), nil
 	}
-
-	// Append applicability filter if enabled (default).
-	// Prose personas get a writing-appropriate filter; code personas get the original.
-	if h.cfg.Config.StrictFilter {
-		if analyzer.IsProsePersona(persona) {
-			personaPrompt += analyzer.ProseApplicabilityFilterPrompt
-		} else {
-			personaPrompt += analyzer.ApplicabilityFilterPrompt
-		}
-	}
-
-	opts := []analyzer.TieredAnalyzerOption{}
-	if len(h.rules) > 0 {
-		opts = append(opts, analyzer.WithInstantPatterns(h.rules))
-	}
-
-	ta := analyzer.NewTieredAnalyzer(h.client, opts...)
-	return ta.Analyze(ctx, artifacts, h.cfg.Config.Policies, personaPrompt)
+	return mcp.NewToolResultText(string(out)), nil
 }
 
 // validatePath checks that the resolved path is within the configured root directory
@@ -1071,24 +915,4 @@ func (h *handlers) validatePath(path string) error {
 	}
 
 	return nil
-}
-
-// buildDescriptors assembles SARIF reportingDescriptors from both enabled
-// policies and loaded rules. Rule descriptors carry help/helpUri populated
-// from the rule's remediation, CWE, and reference metadata.
-func buildDescriptors(policies map[string]config.Policy, loadedRules []rules.Rule) []sarif.ReportingDescriptor {
-	var descriptors []sarif.ReportingDescriptor
-	for name, p := range policies {
-		if p.Enabled {
-			descriptors = append(descriptors, sarif.ReportingDescriptor{
-				ID:               name,
-				ShortDescription: sarif.Message{Text: p.Description},
-				DefaultConfig:    &sarif.ReportingConfiguration{Level: p.Severity},
-			})
-		}
-	}
-	for _, r := range loadedRules {
-		descriptors = append(descriptors, r.ToSARIFDescriptor())
-	}
-	return descriptors
 }

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/chris-regnier/gavel/internal/config"
 	"github.com/chris-regnier/gavel/internal/rules"
 	"github.com/chris-regnier/gavel/internal/sarif"
+	"github.com/chris-regnier/gavel/internal/service"
 	"github.com/chris-regnier/gavel/internal/store"
 	"github.com/chris-regnier/gavel/internal/suppression"
 	"github.com/stretchr/testify/assert"
@@ -103,6 +104,9 @@ func newTestHandlers(t *testing.T, cfg *config.Config, fs store.Store, rootDir s
 	if client == nil {
 		client = analyzer.NewBAMLLiveClient(cfg.Provider)
 	}
+	analyzeSvc := service.NewAnalyzeService(fs).WithClientFactory(
+		func(_ config.ProviderConfig) analyzer.BAMLClient { return client },
+	)
 	return &handlers{
 		cfg: ServerConfig{
 			Config:  cfg,
@@ -110,8 +114,7 @@ func newTestHandlers(t *testing.T, cfg *config.Config, fs store.Store, rootDir s
 			RootDir: rootDir,
 			Rules:   o.rules,
 		},
-		client: client,
-		rules:  o.rules,
+		analyzeSvc: analyzeSvc,
 	}
 }
 
@@ -708,35 +711,6 @@ func TestReadResultTemplate(t *testing.T) {
 	}
 }
 
-func TestBuildDescriptors(t *testing.T) {
-	policies := map[string]config.Policy{
-		"rule1": {Enabled: true, Description: "desc1", Severity: "warning"},
-		"rule2": {Enabled: false, Description: "desc2", Severity: "error"},
-		"rule3": {Enabled: true, Description: "desc3", Severity: "note"},
-	}
-
-	descriptors := buildDescriptors(policies, nil)
-
-	if len(descriptors) != 2 {
-		t.Errorf("expected 2 enabled rules, got %d", len(descriptors))
-	}
-
-	ruleIDs := make(map[string]bool)
-	for _, r := range descriptors {
-		ruleIDs[r.ID] = true
-	}
-
-	if !ruleIDs["rule1"] {
-		t.Error("missing rule1")
-	}
-	if ruleIDs["rule2"] {
-		t.Error("rule2 should not be included (disabled)")
-	}
-	if !ruleIDs["rule3"] {
-		t.Error("missing rule3")
-	}
-}
-
 func TestValidatePath_InsideRoot(t *testing.T) {
 	root := t.TempDir()
 	h := &handlers{cfg: ServerConfig{RootDir: root}}
@@ -1196,8 +1170,8 @@ func TestExtractChangedLines(t *testing.T) {
 			wantEnd:   16,
 		},
 		{
-			name: "multiple hunks",
-			diff: "@@ -5,3 +5,4 @@ header\n+line\n @@ -20,2 +21,5 @@ other\n+more\n",
+			name:      "multiple hunks",
+			diff:      "@@ -5,3 +5,4 @@ header\n+line\n @@ -20,2 +21,5 @@ other\n+more\n",
 			wantStart: 5,
 			wantEnd:   25,
 		},
@@ -1218,141 +1192,59 @@ func TestExtractChangedLines(t *testing.T) {
 	}
 }
 
-// TestApplyBaseline_StampsAutomationAndCompares is a unit test for the
-// shared applyBaseline helper used by every MCP analyze_* handler. It
-// seeds the store with a baseline run, calls applyBaseline, and asserts
-// that the current log is linked to the baseline GUID and that its
-// results carry baselineState buckets.
-func TestApplyBaseline_StampsAutomationAndCompares(t *testing.T) {
-	dir := t.TempDir()
-	fs := store.NewFileStore(dir)
+// TestAnalyzeFileTool_BaselinePropagates is a handler-level integration
+// test that exercises the baseline wiring: seed a baseline SARIF in the
+// store, call analyze_file, and verify the summary's baseline counts
+// reflect the comparison performed by AnalyzeService. The unit-level
+// baseline plumbing is covered by service tests; this test guards the
+// MCP-to-service handoff.
+func TestAnalyzeFileTool_BaselinePropagates(t *testing.T) {
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "creds.go")
+	require.NoError(t, os.WriteFile(testFile, credentialFixture(), 0644))
+
+	cfg := testConfig()
+	fs := store.NewFileStore(filepath.Join(tmpDir, ".gavel", "results"))
 	ctx := context.Background()
 
-	// Seed a baseline SARIF in the store with one error-level finding
-	// whose content will match a finding in the current run.
+	// Seed a baseline SARIF that does NOT contain the S2068 finding so
+	// the rule fires "new" on this run.
 	baselineLog := sarif.NewLog("gavel", "0.1.0")
 	baselineLog.Runs[0].AutomationDetails = &sarif.RunAutomationDetails{Guid: "prev-run-guid"}
-	baselineLog.Runs[0].Results = []sarif.Result{
-		{
-			RuleID:  "bug-detection",
-			Level:   "error",
-			Message: sarif.Message{Text: "pre-existing"},
-			Locations: []sarif.Location{{PhysicalLocation: sarif.PhysicalLocation{
-				ArtifactLocation: sarif.ArtifactLocation{URI: "a.go"},
-				Region: sarif.Region{
-					StartLine: 10, EndLine: 10,
-					Snippet: &sarif.ArtifactContent{Text: "password := \"hunter2\"\n"},
-				},
-			}}},
-		},
-	}
-	sarif.SetContentFingerprint(&baselineLog.Runs[0].Results[0])
 	baselineID, err := fs.WriteSARIF(ctx, baselineLog)
-	if err != nil {
-		t.Fatalf("seeding baseline: %v", err)
+	require.NoError(t, err)
+
+	defaultRules, err := rules.DefaultRules()
+	require.NoError(t, err)
+	h := newTestHandlers(t, cfg, fs, tmpDir, testHandlerOpts{
+		client: &mockBAMLClient{},
+		rules:  defaultRules,
+	})
+
+	req := mcpgo.CallToolRequest{}
+	req.Params.Name = "analyze_file"
+	req.Params.Arguments = map[string]any{
+		"path":     testFile,
+		"baseline": baselineID,
 	}
 
-	// Build a current log that duplicates the baseline's finding
-	// (should come out unchanged) and adds a new one.
-	current := sarif.NewLog("gavel", "0.1.0")
-	current.Runs[0].Results = []sarif.Result{
-		{
-			RuleID:  "bug-detection",
-			Level:   "error",
-			Message: sarif.Message{Text: "same"},
-			Locations: []sarif.Location{{PhysicalLocation: sarif.PhysicalLocation{
-				ArtifactLocation: sarif.ArtifactLocation{URI: "a.go"},
-				Region: sarif.Region{
-					StartLine: 42, EndLine: 42,
-					Snippet: &sarif.ArtifactContent{Text: "password := \"hunter2\"\n"},
-				},
-			}}},
-		},
-		{
-			RuleID:  "bug-detection",
-			Level:   "warning",
-			Message: sarif.Message{Text: "new"},
-			Locations: []sarif.Location{{PhysicalLocation: sarif.PhysicalLocation{
-				ArtifactLocation: sarif.ArtifactLocation{URI: "b.go"},
-				Region: sarif.Region{
-					StartLine: 1, EndLine: 1,
-					Snippet: &sarif.ArtifactContent{Text: "os.Remove(userPath)\n"},
-				},
-			}}},
-		},
-	}
-	for i := range current.Runs[0].Results {
-		sarif.SetContentFingerprint(&current.Runs[0].Results[i])
-	}
+	result, err := h.handleAnalyzeFile(ctx, req)
+	require.NoError(t, err)
+	require.False(t, result.IsError, "expected success: %+v", result)
 
-	h := newTestHandlers(t, testConfig(), fs, dir)
+	text := result.Content[0].(mcpgo.TextContent).Text
+	var summary map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(text), &summary))
 
-	counts, errResult := h.applyBaseline(ctx, current, baselineID)
-	if errResult != nil {
-		t.Fatalf("applyBaseline returned error result: %v", errResult.Content)
-	}
+	baseline, ok := summary["baseline"].(map[string]interface{})
+	require.True(t, ok, "expected baseline summary in response: %s", text)
+	assert.Equal(t, baselineID, baseline["source"])
+	assert.GreaterOrEqual(t, baseline["new"].(float64), float64(1), "expected at least one new finding")
 
-	if current.Runs[0].AutomationDetails == nil || current.Runs[0].AutomationDetails.Guid == "" {
-		t.Error("expected AutomationDetails.Guid to be stamped on the current run")
-	}
-	if current.Runs[0].BaselineGuid != "prev-run-guid" {
-		t.Errorf("BaselineGuid = %q, want %q", current.Runs[0].BaselineGuid, "prev-run-guid")
-	}
-
-	if counts.New != 1 {
-		t.Errorf("counts.New = %d, want 1", counts.New)
-	}
-	if counts.Unchanged != 1 {
-		t.Errorf("counts.Unchanged = %d, want 1", counts.Unchanged)
-	}
-	if counts.Absent != 0 {
-		t.Errorf("counts.Absent = %d, want 0", counts.Absent)
-	}
-	if counts.Source != baselineID {
-		t.Errorf("counts.Source = %q, want %q", counts.Source, baselineID)
-	}
-}
-
-// TestApplyBaseline_NoBaselineStillStampsGUID verifies that calling
-// applyBaseline with an empty baseline ref stamps automation details
-// (so the next run can chain back to this one) but performs no
-// comparison.
-func TestApplyBaseline_NoBaselineStillStampsGUID(t *testing.T) {
-	dir := t.TempDir()
-	fs := store.NewFileStore(dir)
-
-	current := sarif.NewLog("gavel", "0.1.0")
-	h := newTestHandlers(t, testConfig(), fs, dir)
-
-	counts, errResult := h.applyBaseline(context.Background(), current, "")
-	if errResult != nil {
-		t.Fatalf("unexpected error result: %v", errResult.Content)
-	}
-	if counts != (baselineCounts{}) {
-		t.Errorf("expected zero counts when no baseline, got %+v", counts)
-	}
-	if current.Runs[0].AutomationDetails == nil || current.Runs[0].AutomationDetails.Guid == "" {
-		t.Error("expected AutomationDetails.Guid to be stamped even without a baseline")
-	}
-	if current.Runs[0].BaselineGuid != "" {
-		t.Errorf("expected empty BaselineGuid, got %q", current.Runs[0].BaselineGuid)
-	}
-}
-
-// TestApplyBaseline_MissingBaselineIDReturnsError verifies that a
-// missing baseline ID surfaces an MCP error result rather than silently
-// succeeding.
-func TestApplyBaseline_MissingBaselineIDReturnsError(t *testing.T) {
-	dir := t.TempDir()
-	fs := store.NewFileStore(dir)
-	current := sarif.NewLog("gavel", "0.1.0")
-
-	h := newTestHandlers(t, testConfig(), fs, dir)
-	_, errResult := h.applyBaseline(context.Background(), current, "does-not-exist")
-	if errResult == nil {
-		t.Fatal("expected error result for missing baseline id")
-	}
-	if !errResult.IsError {
-		t.Error("expected IsError=true on returned result")
-	}
+	id, ok := summary["id"].(string)
+	require.True(t, ok)
+	stored, err := fs.ReadSARIF(ctx, id)
+	require.NoError(t, err)
+	require.Len(t, stored.Runs, 1)
+	assert.Equal(t, "prev-run-guid", stored.Runs[0].BaselineGuid, "stored run should chain back to baseline guid")
 }

--- a/internal/service/analyze.go
+++ b/internal/service/analyze.go
@@ -3,6 +3,8 @@ package service
 import (
 	"context"
 	"fmt"
+	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/chris-regnier/gavel/internal/analyzer"
@@ -11,6 +13,7 @@ import (
 	"github.com/chris-regnier/gavel/internal/rules"
 	"github.com/chris-regnier/gavel/internal/sarif"
 	"github.com/chris-regnier/gavel/internal/store"
+	"github.com/chris-regnier/gavel/internal/suppression"
 )
 
 // ClientFactory creates a BAMLClient from provider config.
@@ -40,30 +43,25 @@ func (s *AnalyzeService) WithClientFactory(f ClientFactory) *AnalyzeService {
 
 // Analyze runs all tiers synchronously and stores the SARIF result.
 func (s *AnalyzeService) Analyze(ctx context.Context, req AnalyzeRequest) (*AnalyzeResult, error) {
-	client := s.clientFactory(req.Config.Provider)
-
-	personaPrompt, err := analyzer.GetPersonaPrompt(ctx, req.Config.Persona)
+	personaPrompt, err := buildPersonaPrompt(ctx, req.Config)
 	if err != nil {
-		return nil, fmt.Errorf("getting persona prompt: %w", err)
+		return nil, err
 	}
 
-	opts := []analyzer.TieredAnalyzerOption{}
-	if len(req.Rules) > 0 {
-		opts = append(opts, analyzer.WithInstantPatterns(req.Rules))
-	}
-
-	ta := analyzer.NewTieredAnalyzer(client, opts...)
+	ta := analyzer.NewTieredAnalyzer(s.clientFactory(req.Config.Provider), tieredOptions(req.Rules)...)
 	results, err := ta.Analyze(ctx, req.Artifacts, req.Config.Policies, personaPrompt)
 	if err != nil {
 		return nil, fmt.Errorf("analyzing: %w", err)
 	}
 
-	sarifLog := sarif.Assemble(results, buildDescriptors(req.Config.Policies, req.Rules), scopeFromArtifacts(req.Artifacts), req.Config.Persona)
+	sarifLog := sarif.Assemble(results, BuildDescriptors(req.Config.Policies, req.Rules), scopeFromArtifacts(req.Artifacts), req.Config.Persona)
 
 	baselineSummary, err := s.applyBaseline(ctx, sarifLog, req.BaselineID)
 	if err != nil {
 		return nil, err
 	}
+
+	suppressedCount := applySuppressions(sarifLog, req.SuppressionDir)
 
 	resultID, err := s.store.WriteSARIF(ctx, sarifLog)
 	if err != nil {
@@ -72,27 +70,97 @@ func (s *AnalyzeService) Analyze(ctx context.Context, req AnalyzeRequest) (*Anal
 
 	return &AnalyzeResult{
 		ResultID:      resultID,
-		TotalFindings: len(results),
+		TotalFindings: countFindings(sarifLog),
+		Suppressed:    suppressedCount,
+		Baseline:      baselineSummary,
+	}, nil
+}
+
+// AnalyzeScoped runs a diff-style scoped analysis: the instant tier
+// runs against the full file artifact while the comprehensive tier
+// runs against a window around the changed lines. Findings outside
+// the changed-line range are filtered out before assembly. This is the
+// shared entrypoint used by MCP's analyze_diff tool.
+func (s *AnalyzeService) AnalyzeScoped(ctx context.Context, req ScopedAnalyzeRequest) (*AnalyzeResult, error) {
+	if req.ChangedStart <= 0 || req.ChangedEnd <= 0 || req.ChangedStart > req.ChangedEnd {
+		return nil, fmt.Errorf("invalid changed range [%d, %d]", req.ChangedStart, req.ChangedEnd)
+	}
+
+	personaPrompt, err := buildPersonaPrompt(ctx, req.Config)
+	if err != nil {
+		return nil, err
+	}
+
+	ta := analyzer.NewTieredAnalyzer(s.clientFactory(req.Config.Provider), tieredOptions(req.Rules)...)
+
+	// Instant tier on the full file, then filter to the changed range.
+	fullArtifact := input.Artifact{Path: req.Artifact.Path, Content: req.Artifact.Content, Kind: input.KindFile}
+	instantResults := filterByLineRange(ta.RunPatternMatching(fullArtifact), req.ChangedStart, req.ChangedEnd)
+
+	// Comprehensive tier on a window around the changed range.
+	contextWindow := req.ContextWindow
+	if contextWindow <= 0 {
+		contextWindow = 10
+	}
+	scopedContent, scopeStart := windowedContent(req.Artifact.Content, req.ChangedStart, req.ChangedEnd, contextWindow)
+	scopedArtifact := []input.Artifact{{Path: req.Artifact.Path, Content: scopedContent, Kind: input.KindFile}}
+	comprehensiveResults, err := ta.Analyze(ctx, scopedArtifact, req.Config.Policies, personaPrompt)
+	if err != nil {
+		return nil, fmt.Errorf("analyzing: %w", err)
+	}
+
+	// The LLM saw the scope starting at line 1; shift back to the
+	// real file line numbers, then drop anything outside the changed
+	// range. The instant tier already used real line numbers.
+	offset := scopeStart - 1
+	for i := range comprehensiveResults {
+		if len(comprehensiveResults[i].Locations) > 0 {
+			comprehensiveResults[i].Locations[0].PhysicalLocation.Region.StartLine += offset
+			comprehensiveResults[i].Locations[0].PhysicalLocation.Region.EndLine += offset
+		}
+	}
+	comprehensiveResults = filterByLineRange(comprehensiveResults, req.ChangedStart, req.ChangedEnd)
+
+	allResults := append(instantResults, comprehensiveResults...)
+	sarifLog := sarif.Assemble(allResults, BuildDescriptors(req.Config.Policies, req.Rules), "diff", req.Config.Persona)
+
+	baselineSummary, err := s.applyBaseline(ctx, sarifLog, req.BaselineID)
+	if err != nil {
+		return nil, err
+	}
+
+	suppressedCount := applySuppressions(sarifLog, req.SuppressionDir)
+
+	resultID, err := s.store.WriteSARIF(ctx, sarifLog)
+	if err != nil {
+		return nil, fmt.Errorf("storing SARIF: %w", err)
+	}
+
+	return &AnalyzeResult{
+		ResultID:      resultID,
+		TotalFindings: countFindings(sarifLog),
+		Suppressed:    suppressedCount,
 		Baseline:      baselineSummary,
 	}, nil
 }
 
 // applyBaseline stamps automation details onto sarifLog and, when
-// baselineID is non-empty, loads that baseline from the store and
-// annotates each result with a baselineState. Returns a BaselineSummary
-// with bucket counts when comparison ran, or nil when it didn't.
-func (s *AnalyzeService) applyBaseline(ctx context.Context, sarifLog *sarif.Log, baselineID string) (*BaselineSummary, error) {
+// baselineRef is non-empty, loads that baseline (by stored ID or file
+// path) and annotates each result with a baselineState. Returns a
+// BaselineSummary with bucket counts when comparison ran, or nil when
+// it didn't.
+func (s *AnalyzeService) applyBaseline(ctx context.Context, sarifLog *sarif.Log, baselineRef string) (*BaselineSummary, error) {
 	sarif.EnsureAutomationDetails(sarifLog)
-	if baselineID == "" {
+	if baselineRef == "" {
 		return nil, nil
 	}
-	baselineLog, err := s.store.ReadSARIF(ctx, baselineID)
+	baselineLog, err := store.LoadBaseline(ctx, s.store, baselineRef)
 	if err != nil {
-		return nil, fmt.Errorf("loading baseline %q: %w", baselineID, err)
+		return nil, fmt.Errorf("loading baseline %q: %w", baselineRef, err)
 	}
 	sarif.CompareBaseline(sarifLog, baselineLog)
 
-	summary := &BaselineSummary{Source: baselineID}
+	summary := &BaselineSummary{Source: baselineRef}
 	if len(sarifLog.Runs) > 0 {
 		for _, r := range sarifLog.Runs[0].Results {
 			switch r.BaselineState {
@@ -122,20 +190,13 @@ func (s *AnalyzeService) AnalyzeStream(ctx context.Context, req AnalyzeRequest) 
 		defer close(resultCh) // runs 2nd
 		defer close(tierCh)   // runs 1st
 
-		client := s.clientFactory(req.Config.Provider)
-
-		personaPrompt, err := analyzer.GetPersonaPrompt(ctx, req.Config.Persona)
+		personaPrompt, err := buildPersonaPrompt(ctx, req.Config)
 		if err != nil {
-			errCh <- fmt.Errorf("getting persona prompt: %w", err)
+			errCh <- err
 			return
 		}
 
-		opts := []analyzer.TieredAnalyzerOption{}
-		if len(req.Rules) > 0 {
-			opts = append(opts, analyzer.WithInstantPatterns(req.Rules))
-		}
-
-		ta := analyzer.NewTieredAnalyzer(client, opts...)
+		ta := analyzer.NewTieredAnalyzer(s.clientFactory(req.Config.Provider), tieredOptions(req.Rules)...)
 		progressive := ta.AnalyzeProgressive(ctx, req.Artifacts, req.Config.Policies, personaPrompt)
 
 		// Aggregate TieredResults by tier for SSE events
@@ -186,13 +247,15 @@ func (s *AnalyzeService) AnalyzeStream(ctx context.Context, req AnalyzeRequest) 
 		}
 
 		// Store final SARIF
-		sarifLog := sarif.Assemble(allResults, buildDescriptors(req.Config.Policies, req.Rules), scopeFromArtifacts(req.Artifacts), req.Config.Persona)
+		sarifLog := sarif.Assemble(allResults, BuildDescriptors(req.Config.Policies, req.Rules), scopeFromArtifacts(req.Artifacts), req.Config.Persona)
 
 		baselineSummary, baselineErr := s.applyBaseline(ctx, sarifLog, req.BaselineID)
 		if baselineErr != nil {
 			errCh <- baselineErr
 			return
 		}
+
+		suppressedCount := applySuppressions(sarifLog, req.SuppressionDir)
 
 		resultID, err := s.store.WriteSARIF(ctx, sarifLog)
 		if err != nil {
@@ -202,7 +265,8 @@ func (s *AnalyzeService) AnalyzeStream(ctx context.Context, req AnalyzeRequest) 
 
 		resultCh <- AnalyzeResult{
 			ResultID:      resultID,
-			TotalFindings: len(allResults),
+			TotalFindings: countFindings(sarifLog),
+			Suppressed:    suppressedCount,
 			Baseline:      baselineSummary,
 		}
 	}()
@@ -210,10 +274,100 @@ func (s *AnalyzeService) AnalyzeStream(ctx context.Context, req AnalyzeRequest) 
 	return tierCh, resultCh, errCh
 }
 
-// buildDescriptors assembles SARIF reportingDescriptors from both enabled
+// buildPersonaPrompt resolves the persona prompt and, when StrictFilter
+// is enabled, appends the appropriate applicability filter (prose vs
+// code). Mirrors the CLI's persona handling so every entrypoint
+// produces the same prompt.
+func buildPersonaPrompt(ctx context.Context, cfg config.Config) (string, error) {
+	prompt, err := analyzer.GetPersonaPrompt(ctx, cfg.Persona)
+	if err != nil {
+		return "", fmt.Errorf("getting persona prompt: %w", err)
+	}
+	if cfg.StrictFilter {
+		if analyzer.IsProsePersona(cfg.Persona) {
+			prompt += analyzer.ProseApplicabilityFilterPrompt
+		} else {
+			prompt += analyzer.ApplicabilityFilterPrompt
+		}
+	}
+	return prompt, nil
+}
+
+func tieredOptions(loadedRules []rules.Rule) []analyzer.TieredAnalyzerOption {
+	if len(loadedRules) == 0 {
+		return nil
+	}
+	return []analyzer.TieredAnalyzerOption{analyzer.WithInstantPatterns(loadedRules)}
+}
+
+// applySuppressions loads .gavel/suppressions.yaml from rootDir and
+// stamps matching results in sarifLog. A zero rootDir disables
+// suppression handling. Returns how many results ended up suppressed.
+func applySuppressions(sarifLog *sarif.Log, rootDir string) int {
+	if rootDir == "" {
+		return 0
+	}
+	supps, err := suppression.Load(rootDir)
+	if err != nil {
+		slog.Warn("failed to load suppressions", "err", err, "root", rootDir)
+		return 0
+	}
+	suppression.Apply(supps, sarifLog)
+	count := 0
+	for _, run := range sarifLog.Runs {
+		for _, r := range run.Results {
+			if len(r.Suppressions) > 0 {
+				count++
+			}
+		}
+	}
+	return count
+}
+
+func countFindings(sarifLog *sarif.Log) int {
+	if len(sarifLog.Runs) == 0 {
+		return 0
+	}
+	return len(sarifLog.Runs[0].Results)
+}
+
+// filterByLineRange keeps only results whose first location's StartLine
+// falls within [start, end] inclusive. Results without a location are
+// dropped.
+func filterByLineRange(results []sarif.Result, start, end int) []sarif.Result {
+	var out []sarif.Result
+	for _, r := range results {
+		if len(r.Locations) == 0 {
+			continue
+		}
+		line := r.Locations[0].PhysicalLocation.Region.StartLine
+		if line >= start && line <= end {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// windowedContent returns the substring of content covering
+// [start-window, end+window] (clamped to the file bounds), along with
+// the 1-indexed line where the window begins. Lines are split on "\n".
+func windowedContent(content string, start, end, window int) (string, int) {
+	lines := strings.Split(content, "\n")
+	scopeStart := start - window
+	if scopeStart < 1 {
+		scopeStart = 1
+	}
+	scopeEnd := end + window
+	if scopeEnd > len(lines) {
+		scopeEnd = len(lines)
+	}
+	return strings.Join(lines[scopeStart-1:scopeEnd], "\n"), scopeStart
+}
+
+// BuildDescriptors assembles SARIF reportingDescriptors from both enabled
 // policies and loaded rules. Rule descriptors carry help/helpUri populated
 // from the rule's remediation, CWE, and reference metadata.
-func buildDescriptors(policies map[string]config.Policy, loadedRules []rules.Rule) []sarif.ReportingDescriptor {
+func BuildDescriptors(policies map[string]config.Policy, loadedRules []rules.Rule) []sarif.ReportingDescriptor {
 	var descriptors []sarif.ReportingDescriptor
 	for name, p := range policies {
 		if p.Enabled {

--- a/internal/service/analyze_test.go
+++ b/internal/service/analyze_test.go
@@ -2,14 +2,20 @@ package service
 
 import (
 	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/chris-regnier/gavel/internal/analyzer"
 	"github.com/chris-regnier/gavel/internal/config"
 	"github.com/chris-regnier/gavel/internal/input"
+	"github.com/chris-regnier/gavel/internal/rules"
 	"github.com/chris-regnier/gavel/internal/sarif"
 	"github.com/chris-regnier/gavel/internal/store"
+	"github.com/chris-regnier/gavel/internal/suppression"
 )
 
 // mockStore implements store.Store for testing.
@@ -50,6 +56,22 @@ func (m *mockStore) List(_ context.Context) ([]string, error) {
 type mockBAMLClient struct{}
 
 func (m *mockBAMLClient) AnalyzeCode(_ context.Context, _ string, _ string, _ string, _ string) ([]analyzer.Finding, error) {
+	return nil, nil
+}
+
+// promptCapturingClient records the personaPrompt argument seen by
+// AnalyzeCode so tests can assert that StrictFilter (and other
+// prompt-affecting settings) flow through the service. The BAMLClient
+// signature is (ctx, code, policies, personaPrompt, additionalContext).
+type promptCapturingClient struct {
+	mu      sync.Mutex
+	prompts []string
+}
+
+func (m *promptCapturingClient) AnalyzeCode(_ context.Context, _ string, _ string, personaPrompt string, _ string) ([]analyzer.Finding, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.prompts = append(m.prompts, personaPrompt)
 	return nil, nil
 }
 
@@ -269,5 +291,213 @@ func TestAnalyzeService_AnalyzeStream(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	default:
+	}
+}
+
+// TestAnalyzeService_StrictFilterAppendsApplicabilityPrompt verifies
+// that the configured StrictFilter appends the code-flavored
+// applicability filter on the persona prompt for non-prose personas,
+// and that the marker is absent when StrictFilter is disabled.
+func TestAnalyzeService_StrictFilterAppendsApplicabilityPrompt(t *testing.T) {
+	const filterMarker = "===== APPLICABILITY FILTER ====="
+
+	cases := []struct {
+		name         string
+		persona      string
+		strictFilter bool
+		wantMarker   bool
+	}{
+		{name: "code persona with strict filter", persona: "code-reviewer", strictFilter: true, wantMarker: true},
+		{name: "code persona without strict filter", persona: "code-reviewer", strictFilter: false, wantMarker: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			capture := &promptCapturingClient{}
+			svc := NewAnalyzeService(&mockStore{}).WithClientFactory(func(_ config.ProviderConfig) analyzer.BAMLClient {
+				return capture
+			})
+
+			_, err := svc.Analyze(context.Background(), AnalyzeRequest{
+				Artifacts: []input.Artifact{{Path: "test.go", Content: "package main\n", Kind: input.KindFile}},
+				Config: config.Config{
+					Provider:     config.ProviderConfig{Name: "test"},
+					Persona:      tc.persona,
+					StrictFilter: tc.strictFilter,
+					Policies: map[string]config.Policy{
+						"bug-detection": {Enabled: true, Description: "Find bugs", Severity: "warning"},
+					},
+				},
+			})
+			if err != nil {
+				t.Fatalf("Analyze: %v", err)
+			}
+			capture.mu.Lock()
+			defer capture.mu.Unlock()
+			if len(capture.prompts) == 0 {
+				t.Fatal("expected at least one prompt to be captured")
+			}
+			prompt := capture.prompts[0]
+			has := strings.Contains(prompt, filterMarker)
+			if has != tc.wantMarker {
+				t.Errorf("filter marker present = %v, want %v\nprompt:\n%s", has, tc.wantMarker, prompt)
+			}
+		})
+	}
+}
+
+// TestAnalyzeService_SuppressionsApplied verifies that SuppressionDir
+// causes matching .gavel/suppressions.yaml entries to be stamped on
+// SARIF results before storage.
+func TestAnalyzeService_SuppressionsApplied(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".gavel"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := suppression.Save(dir, []suppression.Suppression{
+		{RuleID: "S2068", Reason: "test fixture", Source: "test", Created: time.Now().UTC()},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	defaultRules, err := rules.DefaultRules()
+	if err != nil {
+		t.Fatalf("DefaultRules: %v", err)
+	}
+
+	// Use a credential pattern that fires S2068 in the instant tier.
+	keyword := "pass" + "word"
+	src := "package main\n\nvar " + keyword + " = \"hunter2hunter2\"\n"
+
+	ms := &mockStore{}
+	svc := NewAnalyzeService(ms).WithClientFactory(func(_ config.ProviderConfig) analyzer.BAMLClient {
+		return &mockBAMLClient{}
+	})
+
+	result, err := svc.Analyze(context.Background(), AnalyzeRequest{
+		Artifacts: []input.Artifact{{Path: filepath.Join(dir, "creds.go"), Content: src, Kind: input.KindFile}},
+		Config: config.Config{
+			Provider: config.ProviderConfig{Name: "test"},
+			Persona:  "code-reviewer",
+			Policies: map[string]config.Policy{
+				"bug-detection": {Enabled: true, Description: "Find bugs", Severity: "warning"},
+			},
+		},
+		Rules:          defaultRules,
+		SuppressionDir: dir,
+	})
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	if result.Suppressed == 0 {
+		t.Errorf("expected at least one suppressed result, got %d", result.Suppressed)
+	}
+	if ms.writtenSARIF == nil || len(ms.writtenSARIF.Runs) == 0 {
+		t.Fatal("expected SARIF to be written")
+	}
+	stampedAny := false
+	for _, r := range ms.writtenSARIF.Runs[0].Results {
+		if r.RuleID == "S2068" && len(r.Suppressions) > 0 {
+			stampedAny = true
+			break
+		}
+	}
+	if !stampedAny {
+		t.Error("expected S2068 result to carry a SARIF suppression entry")
+	}
+}
+
+// TestAnalyzeService_AnalyzeScoped verifies that AnalyzeScoped runs
+// the instant tier on the full file but only keeps findings whose line
+// falls inside the requested changed range. The credential fixture is
+// arranged so the rule fires on line 3; we ask for [3,3] (kept) and
+// [10,10] (filtered out) and assert the difference.
+func TestAnalyzeService_AnalyzeScoped(t *testing.T) {
+	defaultRules, err := rules.DefaultRules()
+	if err != nil {
+		t.Fatalf("DefaultRules: %v", err)
+	}
+
+	keyword := "pass" + "word"
+	src := "package main\n\nvar " + keyword + " = \"hunter2hunter2\"\n\n\n\n\n\n\n\n\n\n"
+
+	cases := []struct {
+		name        string
+		start, end  int
+		expectFires bool
+	}{
+		{"changed range covers credential", 3, 3, true},
+		{"changed range elsewhere", 10, 10, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ms := &mockStore{}
+			svc := NewAnalyzeService(ms).WithClientFactory(func(_ config.ProviderConfig) analyzer.BAMLClient {
+				return &mockBAMLClient{}
+			})
+
+			result, err := svc.AnalyzeScoped(context.Background(), ScopedAnalyzeRequest{
+				Artifact:     input.Artifact{Path: "creds.go", Content: src, Kind: input.KindFile},
+				ChangedStart: tc.start,
+				ChangedEnd:   tc.end,
+				Config: config.Config{
+					Provider: config.ProviderConfig{Name: "test"},
+					Persona:  "code-reviewer",
+					Policies: map[string]config.Policy{
+						"bug-detection": {Enabled: true, Description: "Find bugs", Severity: "warning"},
+					},
+				},
+				Rules: defaultRules,
+			})
+			if err != nil {
+				t.Fatalf("AnalyzeScoped: %v", err)
+			}
+
+			fires := false
+			if ms.writtenSARIF != nil && len(ms.writtenSARIF.Runs) > 0 {
+				for _, r := range ms.writtenSARIF.Runs[0].Results {
+					if r.RuleID == "S2068" {
+						fires = true
+						break
+					}
+				}
+			}
+			if fires != tc.expectFires {
+				t.Errorf("S2068 fired = %v, want %v (TotalFindings=%d)", fires, tc.expectFires, result.TotalFindings)
+			}
+		})
+	}
+}
+
+// TestBuildDescriptors covers the policy-vs-rule descriptor assembly
+// shared by every entrypoint. Disabled policies are omitted; loaded
+// rules are appended.
+func TestBuildDescriptors(t *testing.T) {
+	policies := map[string]config.Policy{
+		"rule1": {Enabled: true, Description: "desc1", Severity: "warning"},
+		"rule2": {Enabled: false, Description: "desc2", Severity: "error"},
+		"rule3": {Enabled: true, Description: "desc3", Severity: "note"},
+	}
+
+	descriptors := BuildDescriptors(policies, nil)
+
+	if len(descriptors) != 2 {
+		t.Errorf("expected 2 enabled rules, got %d", len(descriptors))
+	}
+
+	ruleIDs := make(map[string]bool)
+	for _, r := range descriptors {
+		ruleIDs[r.ID] = true
+	}
+
+	if !ruleIDs["rule1"] {
+		t.Error("missing rule1")
+	}
+	if ruleIDs["rule2"] {
+		t.Error("rule2 should not be included (disabled)")
+	}
+	if !ruleIDs["rule3"] {
+		t.Error("missing rule3")
 	}
 }

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -19,8 +19,39 @@ type AnalyzeRequest struct {
 	// BaselineID, if non-empty, identifies a previously stored SARIF
 	// result to compare against. Each finding in the new run will be
 	// annotated with a baselineState (new, unchanged, or absent).
-	// Empty disables baseline comparison.
+	// May also be a path to a sarif.json file. Empty disables baseline
+	// comparison.
 	BaselineID string
+	// SuppressionDir, if non-empty, points at the project root that
+	// contains .gavel/suppressions.yaml. The service will load and
+	// stamp matching suppressions on the SARIF results before storing.
+	// Empty disables suppression handling entirely.
+	SuppressionDir string
+}
+
+// ScopedAnalyzeRequest describes a scoped diff analysis: the instant
+// tier runs against the full file artifact, the comprehensive tier
+// runs against a content window around the changed lines, and findings
+// outside the changed range are filtered out before assembly.
+type ScopedAnalyzeRequest struct {
+	// Artifact is the full file. Its Content drives the instant tier
+	// directly; the comprehensive tier sees a windowed slice around
+	// [ChangedStart, ChangedEnd].
+	Artifact input.Artifact
+	// ChangedStart and ChangedEnd are 1-indexed line numbers describing
+	// the changed region. Findings whose StartLine falls outside this
+	// range are filtered out.
+	ChangedStart int
+	ChangedEnd   int
+	// ContextWindow is the number of lines on either side of the
+	// changed region included in the comprehensive-tier scope. Zero
+	// uses the default (10).
+	ContextWindow int
+	Config        config.Config
+	Rules         []rules.Rule
+	// BaselineID and SuppressionDir behave identically to AnalyzeRequest.
+	BaselineID     string
+	SuppressionDir string
 }
 
 // TierResult represents results from a single analysis tier.
@@ -43,9 +74,13 @@ type BaselineSummary struct {
 
 // AnalyzeResult is the final summary after all tiers complete.
 type AnalyzeResult struct {
-	ResultID      string           `json:"result_id"`
-	TotalFindings int              `json:"total_findings"`
-	Baseline      *BaselineSummary `json:"baseline,omitempty"`
+	ResultID      string `json:"result_id"`
+	TotalFindings int    `json:"total_findings"`
+	// Suppressed counts results that ended up with at least one
+	// SARIF suppression entry stamped by .gavel/suppressions.yaml.
+	// Zero when SuppressionDir was empty.
+	Suppressed int              `json:"suppressed,omitempty"`
+	Baseline   *BaselineSummary `json:"baseline,omitempty"`
 }
 
 // JudgeRequest is the transport-agnostic input for evaluation.


### PR DESCRIPTION
The CLI, HTTP service, and MCP server all built their own analysis
pipelines. That triple-maintenance burden caused #105 (rules wired
into CLI and service but forgotten in MCP). This change consolidates
MCP onto AnalyzeService so file/dir/diff analysis flows through one
entrypoint shared with the HTTP service.

Service changes
- AnalyzeRequest gains SuppressionDir; the service now loads
  .gavel/suppressions.yaml and stamps matching results before storage
  when the field is set, matching CLI/MCP behavior.
- Persona prompt construction moves into the service and applies the
  StrictFilter applicability filter (prose vs code) once, instead of
  duplicating that branch at every caller.
- applyBaseline now uses store.LoadBaseline so any caller can pass
  either a stored result ID or a path to a sarif.json file (MCP
  already supported this; the service used to be ID-only).
- New AnalyzeScoped method encapsulates MCP's diff flow: instant tier
  on the full file, comprehensive tier on a windowed slice around
  the changed range, line-number offset adjustment, and post-filter
  to the changed range.
- AnalyzeResult adds Suppressed count.

MCP changes
- handleAnalyzeFile / handleAnalyzeDirectory build an AnalyzeRequest
  and call svc.Analyze; handleAnalyzeDiff builds a ScopedAnalyzeRequest
  and calls svc.AnalyzeScoped.
- The BAML client is still constructed once at startup and fed to the
  service via WithClientFactory, preserving the previous "build once"
  cost model.
- Local helpers runAnalysis, applyBaseline, baselineCounts, and the
  duplicated buildDescriptors are removed.
- Suppression tools (suppress_finding, list_suppressions,
  unsuppress_finding) and the judge tool are unchanged.

Tests
- Service: new coverage for SuppressionDir, StrictFilter prompt
  augmentation, AnalyzeScoped line-range filtering, and
  BuildDescriptors (relocated from MCP).
- MCP: applyBaseline unit tests retired in favor of a handler-level
  baseline propagation test that exercises the new wiring; existing
  rule-firing regression tests for #105 still pass.

https://claude.ai/code/session_01SuYfgYiYH1tZ6b6158few2