### PR TITLE
ci(release): smoke-test native binary before upload (#89)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,17 @@ jobs:
       - name: Build Linux binaries
         run: task build:release
 
+      - name: Smoke test native binary
+        run: |
+          case "$(uname -m)" in
+            x86_64) ARCH=x86_64 ;;
+            aarch64|arm64) ARCH=arm64 ;;
+            *) echo "Unsupported arch: $(uname -m)" >&2; exit 1 ;;
+          esac
+          BIN="dist/gavel_Linux_${ARCH}"
+          echo "Running ${BIN} --version"
+          "${BIN}" --version
+
       - name: Upload Linux artifacts
         uses: actions/upload-artifact@v7
         with:
@@ -83,6 +94,17 @@ jobs:
 
       - name: Build macOS binaries
         run: task build:release
+
+      - name: Smoke test native binary
+        run: |
+          case "$(uname -m)" in
+            x86_64) ARCH=x86_64 ;;
+            arm64|aarch64) ARCH=arm64 ;;
+            *) echo "Unsupported arch: $(uname -m)" >&2; exit 1 ;;
+          esac
+          BIN="dist/gavel_Darwin_${ARCH}"
+          echo "Running ${BIN} --version"
+          "${BIN}" --version
 
       - name: Upload macOS artifacts
         uses: actions/upload-artifact@v7

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -192,6 +192,21 @@ tasks:
       - echo "==> Building release binaries for current OS..."
       - task: build:release
       - |
+        echo "==> Smoke testing native binary..."
+        case "$(uname -s)" in
+          Linux) OS=Linux ;;
+          Darwin) OS=Darwin ;;
+          *) echo "Unsupported OS: $(uname -s)" >&2; exit 1 ;;
+        esac
+        case "$(uname -m)" in
+          x86_64) ARCH=x86_64 ;;
+          arm64|aarch64) ARCH=arm64 ;;
+          *) echo "Unsupported arch: $(uname -m)" >&2; exit 1 ;;
+        esac
+        BIN="dist/gavel_${OS}_${ARCH}"
+        echo "Running ${BIN} --version"
+        "${BIN}" --version
+      - |
         echo "==> Generating changelog..."
         PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
         if [ -n "$PREV_TAG" ]; then


### PR DESCRIPTION
Run the freshly built binary's `--version` after `task build:release` and
before artifact upload on each release runner. Catches link errors, missing
CGO shared libs, or runtime init panics that a successful compile alone
cannot prove. Failure aborts the release.

The smoke test runs only the binary that matches the runner's native arch
(detected via `uname -m`); cross-arch artifacts (e.g. linux/arm64 on the
amd64 runner) are still produced but skipped, since #90 has not yet
introduced native arm64 runners.

Mirror the same step in `task release:dry-run` so local rehearsals exercise
the same gate as CI.